### PR TITLE
Feature/#1 entity modeling

### DIFF
--- a/src/main/java/com/jvnlee/catchdining/entity/Address.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Address.java
@@ -1,0 +1,18 @@
+package com.jvnlee.catchdining.entity;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class Address {
+
+    private String province;
+
+    private String city;
+
+    private String district;
+
+    private String street;
+
+    private String detail;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/BaseEntity.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/CountryType.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/CountryType.java
@@ -1,0 +1,5 @@
+package com.jvnlee.catchdining.entity;
+
+public enum CountryType {
+    KOREAN, JAPANESE, CHINESE, AMERICAN, ITALIAN, FRENCH, SPANISH, FUSION, ETC
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/DiningPeriod.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/DiningPeriod.java
@@ -1,0 +1,5 @@
+package com.jvnlee.catchdining.entity;
+
+public enum DiningPeriod {
+    LUNCH, DINNER
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Favorite.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Favorite.java
@@ -5,23 +5,24 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Favorite {
+public class Favorite extends BaseEntity {
 
     @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "favorite_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/Favorite.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Favorite.java
@@ -1,0 +1,28 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Favorite {
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "favorite_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/FoodType.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/FoodType.java
@@ -1,0 +1,5 @@
+package com.jvnlee.catchdining.entity;
+
+public enum FoodType {
+    BEEF, PORK, LAMB, CHICKEN, DUCK, SEAFOOD, SUSHI, VEGAN, ETC
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Menu.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Menu.java
@@ -5,15 +5,14 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-import java.util.List;
-
+import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Menu {
+public class Menu extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -24,7 +23,7 @@ public class Menu {
 
     private int price;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/Menu.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Menu.java
@@ -1,0 +1,31 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.util.List;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Menu {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "menu_id")
+    private Long id;
+
+    private String name;
+
+    private int price;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Notification.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Notification.java
@@ -1,0 +1,41 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.time.LocalDate;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    private LocalDate desiredDate;
+
+    @Enumerated(EnumType.STRING)
+    private DiningPeriod desiredPeriod;
+
+    private int headCount;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Notification.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Notification.java
@@ -7,13 +7,14 @@ import javax.persistence.*;
 
 import java.time.LocalDate;
 
+import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Notification {
+public class Notification extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -23,11 +24,11 @@ public class Notification {
     @Enumerated(EnumType.STRING)
     private NotificationStatus status;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/NotificationStatus.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/NotificationStatus.java
@@ -1,0 +1,5 @@
+package com.jvnlee.catchdining.entity;
+
+public enum NotificationStatus {
+    WAITING, AVAILABLE, UNAVAILABLE
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Payment.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Payment.java
@@ -13,7 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Payment {
+public class Payment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/com/jvnlee/catchdining/entity/Payment.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Payment.java
@@ -1,0 +1,31 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.util.List;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @OneToMany(mappedBy = "payment")
+    private List<ReserveMenu> reserveMenus;
+
+    private int totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentType paymentType;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Payment.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Payment.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static javax.persistence.GenerationType.IDENTITY;
@@ -21,7 +22,7 @@ public class Payment extends BaseEntity {
     private Long id;
 
     @OneToMany(mappedBy = "payment")
-    private List<ReserveMenu> reserveMenus;
+    private List<ReserveMenu> reserveMenus = new ArrayList<>();
 
     private int totalPrice;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/PaymentType.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/PaymentType.java
@@ -1,0 +1,5 @@
+package com.jvnlee.catchdining.entity;
+
+public enum PaymentType {
+    CREDIT_CARD, NAVER_PAY, KAKAO_PAY
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Reservation.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Reservation.java
@@ -1,0 +1,42 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.time.LocalDateTime;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Reservation {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "reservation_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDateTime time;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id")
+    private Seat seat;
+
+    private int headCount;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id")
+    private Payment payment;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Reservation.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Reservation.java
@@ -7,32 +7,33 @@ import javax.persistence.*;
 
 import java.time.LocalDateTime;
 
+import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Reservation {
+public class Reservation extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "reservation_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     private LocalDateTime time;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = LAZY)
     @JoinColumn(name = "seat_id")
     private Seat seat;
 
     private int headCount;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = LAZY)
     @JoinColumn(name = "payment_id")
     private Payment payment;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/ReservationStatus.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/ReservationStatus.java
@@ -1,0 +1,5 @@
+package com.jvnlee.catchdining.entity;
+
+public enum ReservationStatus {
+    RESERVED, VISITED, NO_SHOW, CANCEL
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/ReserveMenu.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/ReserveMenu.java
@@ -1,0 +1,33 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ReserveMenu {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "reserve_menu_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id")
+    private Payment payment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
+
+    private int reservePrice;
+
+    private int quantity;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/ReserveMenu.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/ReserveMenu.java
@@ -5,24 +5,25 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class ReserveMenu {
+public class ReserveMenu extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "reserve_menu_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "payment_id")
     private Payment payment;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "menu_id")
     private Menu menu;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/Restaurant.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Restaurant.java
@@ -1,0 +1,52 @@
+package com.jvnlee.catchdining.entity;
+
+import com.sun.jdi.PrimitiveValue;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.util.List;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Restaurant {
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "restaurant_id")
+    private Long id;
+
+    private String name;
+
+    @Embedded
+    private Address address;
+
+    private String phoneNumber;
+
+    private String description;
+
+    private double rating;
+
+    @OneToMany(mappedBy = "restaurant")
+    private List<Seat> seats;
+
+    @Enumerated(EnumType.STRING)
+    private CountryType countryType;
+
+    @Enumerated(EnumType.STRING)
+    private FoodType foodType;
+
+    @Enumerated(EnumType.STRING)
+    private ServingType servingType;
+
+    @OneToMany(mappedBy = "restaurant")
+    private List<Menu> menus;
+
+    @OneToMany(mappedBy = "restaurant")
+    private List<Review> reviews;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Restaurant.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Restaurant.java
@@ -14,7 +14,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Restaurant {
+public class Restaurant extends BaseEntity {
 
     @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "restaurant_id")

--- a/src/main/java/com/jvnlee/catchdining/entity/Restaurant.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Restaurant.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static javax.persistence.GenerationType.IDENTITY;
@@ -32,7 +33,7 @@ public class Restaurant extends BaseEntity {
     private double rating;
 
     @OneToMany(mappedBy = "restaurant")
-    private List<Seat> seats;
+    private List<Seat> seats= new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private CountryType countryType;
@@ -44,9 +45,9 @@ public class Restaurant extends BaseEntity {
     private ServingType servingType;
 
     @OneToMany(mappedBy = "restaurant")
-    private List<Menu> menus;
+    private List<Menu> menus = new ArrayList<>();
 
     @OneToMany(mappedBy = "restaurant")
-    private List<Review> reviews;
+    private List<Review> reviews = new ArrayList<>();
 
 }

--- a/src/main/java/com/jvnlee/catchdining/entity/Review.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Review.java
@@ -7,24 +7,25 @@ import javax.persistence.*;
 
 import java.util.List;
 
+import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Review {
+public class Review extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "review_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/Review.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Review.java
@@ -1,0 +1,42 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.util.List;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    private double tasteRating;
+
+    private double moodRating;
+
+    private double serviceRating;
+
+    private String content;
+
+    @OneToMany(mappedBy = "review")
+    private List<ReviewComment> reviewComments;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Review.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Review.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static javax.persistence.FetchType.*;
@@ -38,6 +39,6 @@ public class Review extends BaseEntity {
     private String content;
 
     @OneToMany(mappedBy = "review")
-    private List<ReviewComment> reviewComments;
+    private List<ReviewComment> reviewComments = new ArrayList<>();
 
 }

--- a/src/main/java/com/jvnlee/catchdining/entity/ReviewComment.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/ReviewComment.java
@@ -5,24 +5,25 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class ReviewComment {
+public class ReviewComment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "review_comment_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "review_id")
     private Review review;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/ReviewComment.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/ReviewComment.java
@@ -1,0 +1,30 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ReviewComment {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "review_comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String content;
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Seat.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Seat.java
@@ -8,20 +8,21 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Seat {
+public class Seat extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "seat_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/Seat.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Seat.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static javax.persistence.FetchType.*;
@@ -32,7 +33,7 @@ public class Seat extends BaseEntity {
     @ElementCollection
     @CollectionTable(name = "available_time",
             joinColumns = @JoinColumn(name = "seat_id"))
-    private List<LocalDateTime> availabeTime;
+    private List<LocalDateTime> availabeTime = new ArrayList<>();
 
     private int maxHeadCount;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/Seat.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Seat.java
@@ -1,0 +1,38 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Seat {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "seat_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    @Enumerated(EnumType.STRING)
+    private SeatType seatType;
+
+    @ElementCollection
+    @CollectionTable(name = "available_time",
+            joinColumns = @JoinColumn(name = "seat_id"))
+    private List<LocalDateTime> availabeTime;
+
+    private int maxHeadCount;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/SeatType.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/SeatType.java
@@ -1,0 +1,5 @@
+package com.jvnlee.catchdining.entity;
+
+public enum SeatType {
+    HALL, ROOM, BAR
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/ServingType.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/ServingType.java
@@ -1,0 +1,5 @@
+package com.jvnlee.catchdining.entity;
+
+public enum ServingType {
+    OMAKASE, CUISINE, COURSE, BUFFET, BARBEQUE
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/User.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/User.java
@@ -13,7 +13,7 @@ import static lombok.AccessLevel.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class User {
+public class User extends BaseEntity {
 
     @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "user_id")

--- a/src/main/java/com/jvnlee/catchdining/entity/User.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/User.java
@@ -1,0 +1,40 @@
+package com.jvnlee.catchdining.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.util.List;
+
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class User {
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    private String username;
+
+    private String password;
+
+    private String phoneNumber;
+
+    @OneToMany(mappedBy = "user")
+    private List<Favorite> favorites;
+
+    @OneToMany(mappedBy = "user")
+    private List<Reservation> reservations;
+
+    @OneToMany(mappedBy = "user")
+    private List<Notification> notifications;
+
+    @OneToMany(mappedBy = "user")
+    private List<Review> reviews;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/User.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/User.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static javax.persistence.GenerationType.*;
@@ -26,15 +27,15 @@ public class User extends BaseEntity {
     private String phoneNumber;
 
     @OneToMany(mappedBy = "user")
-    private List<Favorite> favorites;
+    private List<Favorite> favorites = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
-    private List<Reservation> reservations;
+    private List<Reservation> reservations = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
-    private List<Notification> notifications;
+    private List<Notification> notifications = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
-    private List<Review> reviews;
+    private List<Review> reviews = new ArrayList<>();
 
 }


### PR DESCRIPTION
## 구현 내용

### 비즈니스 엔티티
- Favorite: User가 저장해놓은 Restaurant
- Menu: Restaurant가 가진 메뉴
- Notification: User가 신청할 수 있는 빈자리 알림
- Payment: 결제 정보
- Reservation: 예약 정보
- ReserveMenu: 예약 메뉴 (예약 시 선택해야함)
- Restaurant: 식당
- Review: User가 Restaurant에 남길 수 있는 리뷰
- ReviewComment: Review에 남길 수 있는 댓글
- Seat: User가 예약할 수 있는 자리
- User: 사용자

### Auditing 엔티티
- BaseEntity: 서비스 운영에 필요한 데이터 생성날짜와 마지막 수정날짜

### Enum
- CountryType: Restaurant의 메뉴 국적(한식, 일식, 등...)
- DiningPeriod: 점심시간대 또는 저녁시간대
- FoodType: Restaurant의 메뉴 분류(고기, 해산물 등...)
- NotificationStatus: 빈자리 알림의 상태
- PaymentType: 결제 수단
- ReservationStatus: 예약 정보의 상태
- SeatType: 좌석 분류
- ServingType: Restaurant의 음식 제공 방식(오마카세, 코스, 등...)

### 임베디드 타입
- Address: 시/도, 구, 도로명, 상세 주소로 이루어진 주소 데이터

### 상세
- 엔티티는 필드, 연관 관계 세팅만 완료된 상태
- Favorite과 ReserveMenu 엔티티는 각각 User-Restaurant, Payment-Menu의 N:M 관계에서 파생된 연결 테이블을 엔티티 레벨로 승격시킨 것. (1:N + N:1 관계로 풀어냄)
- 모든 엔티티가 BaseEntity를 상속 받아 데이터 생성날짜와 마지막 수정날짜를 저장함
- 연관 관계에 있는 엔티티의 fetch 전략은 N+1 문제를 방지하기 위해 기본적으로 모두 LAZY(지연 로딩)로 설정
- 그 외에 엔티티의 커스텀 생성자와 (양방향 연관 관계인 경우) 연관 관계 편의 메서드를 추가하는 것은 각 도메인의 기능을 개발할 때 붙여나가는 것으로 함.