### PR TITLE
Feature/#3 user api crud

### DIFF
--- a/src/main/java/com/jvnlee/catchdining/CatchdiningApplication.java
+++ b/src/main/java/com/jvnlee/catchdining/CatchdiningApplication.java
@@ -2,8 +2,10 @@ package com.jvnlee.catchdining;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CatchdiningApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/jvnlee/catchdining/common/web/Response.java
+++ b/src/main/java/com/jvnlee/catchdining/common/web/Response.java
@@ -1,0 +1,22 @@
+package com.jvnlee.catchdining.common.web;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Response<T> {
+
+    private String message;
+
+    private T data;
+
+    public Response(T data) {
+        this.data = data;
+    }
+
+    public Response(String message) {
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserController.java
@@ -5,7 +5,11 @@ import com.jvnlee.catchdining.domain.user.dto.UserDto;
 import com.jvnlee.catchdining.domain.user.dto.UserSearchDto;
 import com.jvnlee.catchdining.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.NoSuchElementException;
 
 @RestController
 @RequestMapping("/users")
@@ -36,6 +40,18 @@ public class UserController {
     public Response delete(@PathVariable Long userId) {
         userService.delete(userId);
         return new Response("회원 탈퇴 성공");
+    }
+
+    @ExceptionHandler(DuplicateKeyException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response handleDuplicateData(DuplicateKeyException e) {
+        return new Response(e.getMessage());
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Response handleNoData() {
+        return new Response("해당 username을 가진 사용자가 존재하지 않습니다.");
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserController.java
@@ -1,0 +1,41 @@
+package com.jvnlee.catchdining.domain.user.controller;
+
+import com.jvnlee.catchdining.common.web.Response;
+import com.jvnlee.catchdining.domain.user.dto.UserDto;
+import com.jvnlee.catchdining.domain.user.dto.UserSearchDto;
+import com.jvnlee.catchdining.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping
+    public Response join(UserDto userDto) {
+        userService.join(userDto);
+        return new Response("회원 가입 성공");
+    }
+
+    @GetMapping
+    public Response<UserSearchDto> search(@RequestParam String username) {
+        UserSearchDto data = userService.search(username);
+        return new Response<>("회원 검색 성공", data);
+    }
+
+    @PutMapping("/{userId}")
+    public Response update(@PathVariable Long userId, UserDto userDto) {
+        userService.update(userId, userDto);
+        return new Response("회원 정보 업데이트 성공");
+    }
+
+    @DeleteMapping("/{userId}")
+    public Response delete(@PathVariable Long userId) {
+        userService.delete(userId);
+        return new Response("회원 탈퇴 성공");
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserDto.java
@@ -1,0 +1,26 @@
+package com.jvnlee.catchdining.domain.user.dto;
+
+import com.jvnlee.catchdining.domain.user.model.UserType;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UserDto {
+
+    private String username;
+
+    private String password;
+
+    private String phoneNumber;
+
+    private UserType userType;
+
+    public UserDto(String username, String password, String phoneNumber, UserType userType) {
+        this.username = username;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.userType = userType;
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserSearchDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserSearchDto.java
@@ -1,0 +1,25 @@
+package com.jvnlee.catchdining.domain.user.dto;
+
+import com.jvnlee.catchdining.domain.user.model.User;
+import com.jvnlee.catchdining.entity.Favorite;
+import com.jvnlee.catchdining.entity.Review;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class UserSearchDto {
+
+    private String username;
+
+    private List<Favorite> favorites;
+
+    private List<Review> reviews;
+
+    public UserSearchDto(User user) {
+        this.username = user.getUsername();
+        this.favorites = user.getFavorites();
+        this.reviews = user.getReviews();
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
@@ -22,10 +22,12 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
+    @Column(unique = true)
     private String username;
 
     private String password;
 
+    @Column(unique = true)
     private String phoneNumber;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
@@ -27,6 +27,9 @@ public class User extends BaseEntity {
 
     private String phoneNumber;
 
+    @Enumerated
+    private UserType userType;
+
     @OneToMany(mappedBy = "user")
     private List<Favorite> favorites = new ArrayList<>();
 

--- a/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
@@ -28,7 +28,7 @@ public class User extends BaseEntity {
 
     private String phoneNumber;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private UserType userType;
 
     @OneToMany(mappedBy = "user")

--- a/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
@@ -1,5 +1,6 @@
-package com.jvnlee.catchdining.entity;
+package com.jvnlee.catchdining.domain.user.model;
 
+import com.jvnlee.catchdining.entity.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.domain.user.model;
 
+import com.jvnlee.catchdining.domain.user.dto.UserDto;
 import com.jvnlee.catchdining.entity.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -41,5 +42,18 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user")
     private List<Review> reviews = new ArrayList<>();
+
+    public User(UserDto userDto) {
+        this.username = userDto.getUsername();
+        this.password = userDto.getPassword();
+        this.phoneNumber = userDto.getPhoneNumber();
+        this.userType = userDto.getUserType();
+    }
+
+    public void update(UserDto userDto) {
+        this.username = userDto.getUsername();
+        this.password = userDto.getPassword();
+        this.phoneNumber = userDto.getPhoneNumber();
+    }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/user/model/UserType.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/model/UserType.java
@@ -1,0 +1,5 @@
+package com.jvnlee.catchdining.domain.user.model;
+
+public enum UserType {
+    CUSTOMER, OWNER, ADMIN
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.jvnlee.catchdining.domain.user.repository;
+
+import com.jvnlee.catchdining.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Query("select u from User u where u.username = :username")
+    Optional<User> findByUsername(@Param("username") String username);
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/repository/UserRepository.java
@@ -12,4 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u from User u where u.username = :username")
     Optional<User> findByUsername(@Param("username") String username);
 
+    @Query("select u from User u where u.phoneNumber = :phoneNumber")
+    Optional<User> findByPhoneNumber(@Param("phoneNumber") String phoneNumber);
+
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
@@ -9,6 +9,8 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -30,8 +32,8 @@ public class UserService {
     }
 
     public void update(Long id, UserDto userDto) {
-        validateUsername(userDto);
-        validatePhoneNumber(userDto);
+        validateUsername(id, userDto);
+        validatePhoneNumber(id, userDto);
         User user = userRepository.findById(id).orElseThrow();
         user.update(userDto);
     }
@@ -46,8 +48,24 @@ public class UserService {
         }
     }
 
+    private void validateUsername(Long id, UserDto userDto) {
+        Optional<User> user = userRepository.findByUsername(userDto.getUsername());
+        if (user.isPresent()) {
+            if (user.get().getId().equals(id)) return; // 같은 username을 가진 기존 데이터가 자기 자신인 경우는 패스
+            throw new DuplicateKeyException("이미 존재하는 username 입니다.");
+        }
+    }
+
     private void validatePhoneNumber(UserDto userDto) {
         if (userRepository.findByPhoneNumber(userDto.getPhoneNumber()).isPresent()) {
+            throw new DuplicateKeyException("이미 존재하는 연락처입니다.");
+        }
+    }
+
+    private void validatePhoneNumber(Long id, UserDto userDto) {
+        Optional<User> user = userRepository.findByPhoneNumber(userDto.getPhoneNumber());
+        if (user.isPresent()) {
+            if (user.get().getId().equals(id)) return; // 같은 phoneNumber 가진 기존 데이터가 자기 자신인 경우는 패스
             throw new DuplicateKeyException("이미 존재하는 연락처입니다.");
         }
     }

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.jvnlee.catchdining.domain.user.dto.UserSearchDto;
 import com.jvnlee.catchdining.domain.user.model.User;
 import com.jvnlee.catchdining.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +17,8 @@ public class UserService {
     private final UserRepository userRepository;
 
     public void join(UserDto userDto) {
+        validateUsername(userDto);
+        validatePhoneNumber(userDto);
         User newUser = new User(userDto);
         userRepository.save(newUser);
     }
@@ -27,12 +30,26 @@ public class UserService {
     }
 
     public void update(Long id, UserDto userDto) {
+        validateUsername(userDto);
+        validatePhoneNumber(userDto);
         User user = userRepository.findById(id).orElseThrow();
         user.update(userDto);
     }
 
     public void delete(Long id) {
         userRepository.deleteById(id);
+    }
+
+    private void validateUsername(UserDto userDto) {
+        if (userRepository.findByUsername(userDto.getUsername()).isPresent()) {
+            throw new DuplicateKeyException("이미 존재하는 username 입니다.");
+        }
+    }
+
+    private void validatePhoneNumber(UserDto userDto) {
+        if (userRepository.findByPhoneNumber(userDto.getPhoneNumber()).isPresent()) {
+            throw new DuplicateKeyException("이미 존재하는 연락처입니다.");
+        }
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.jvnlee.catchdining.domain.user.service;
 
 import com.jvnlee.catchdining.domain.user.dto.UserDto;
+import com.jvnlee.catchdining.domain.user.dto.UserSearchDto;
 import com.jvnlee.catchdining.domain.user.model.User;
 import com.jvnlee.catchdining.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +21,9 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public User search(String username) {
-        return userRepository.findByUsername(username).orElseThrow();
+    public UserSearchDto search(String username) {
+        User user = userRepository.findByUsername(username).orElseThrow();
+        return new UserSearchDto(user);
     }
 
     public void update(Long id, UserDto userDto) {

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
@@ -1,0 +1,36 @@
+package com.jvnlee.catchdining.domain.user.service;
+
+import com.jvnlee.catchdining.domain.user.dto.UserDto;
+import com.jvnlee.catchdining.domain.user.model.User;
+import com.jvnlee.catchdining.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public void join(UserDto userDto) {
+        User newUser = new User(userDto);
+        userRepository.save(newUser);
+    }
+
+    @Transactional(readOnly = true)
+    public User search(String username) {
+        return userRepository.findByUsername(username).orElseThrow();
+    }
+
+    public void update(Long id, UserDto userDto) {
+        User user = userRepository.findById(id).orElseThrow();
+        user.update(userDto);
+    }
+
+    public void delete(Long id) {
+        userRepository.deleteById(id);
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Favorite.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Favorite.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.entity;
 
+import com.jvnlee.catchdining.domain.user.model.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/Notification.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.entity;
 
+import com.jvnlee.catchdining.domain.user.model.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/Reservation.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Reservation.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.entity;
 
+import com.jvnlee.catchdining.domain.user.model.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/Review.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Review.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.entity;
 
+import com.jvnlee.catchdining.domain.user.model.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/jvnlee/catchdining/entity/ReviewComment.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/ReviewComment.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.entity;
 
+import com.jvnlee.catchdining.domain.user.model.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/test/java/com/jvnlee/catchdining/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/user/service/UserServiceTest.java
@@ -109,9 +109,11 @@ class UserServiceTest {
     void update_fail_username() {
         Long id = 1L;
         UserDto userDto = new UserDto("user", "123", "01012345678", UserType.CUSTOMER);
-        User user = new User(userDto);
+        User spy = spy(new User(userDto));
+        Optional<User> user = Optional.of(spy);
 
-        when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+        when(userRepository.findByUsername("user")).thenReturn(user);
+        when(user.get().getId()).thenReturn(2L);
 
         assertThatThrownBy(() -> userService.update(id, userDto))
                 .isInstanceOf(DuplicateKeyException.class);
@@ -122,9 +124,11 @@ class UserServiceTest {
     void update_fail_phoneNumber() {
         Long id = 1L;
         UserDto userDto = new UserDto("user", "123", "01012345678", UserType.CUSTOMER);
-        User user = new User(userDto);
+        User spy = spy(new User(userDto));
+        Optional<User> user = Optional.of(spy);
 
-        when(userRepository.findByPhoneNumber("01012345678")).thenReturn(Optional.of(user));
+        when(userRepository.findByPhoneNumber("01012345678")).thenReturn(user);
+        when(user.get().getId()).thenReturn(2L);
 
         assertThatThrownBy(() -> userService.update(id, userDto))
                 .isInstanceOf(DuplicateKeyException.class);

--- a/src/test/java/com/jvnlee/catchdining/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/user/service/UserServiceTest.java
@@ -1,0 +1,140 @@
+package com.jvnlee.catchdining.domain.user.service;
+
+import com.jvnlee.catchdining.domain.user.dto.UserDto;
+import com.jvnlee.catchdining.domain.user.dto.UserSearchDto;
+import com.jvnlee.catchdining.domain.user.model.User;
+import com.jvnlee.catchdining.domain.user.model.UserType;
+import com.jvnlee.catchdining.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    UserService userService;
+
+    @Test
+    @DisplayName("회원 가입 성공")
+    void join_success() {
+        UserDto userDto = new UserDto("user", "123", "01012345678", UserType.CUSTOMER);
+
+        userService.join(userDto);
+
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("회원 가입 실패: 중복된 username")
+    void join_fail_username() {
+        UserDto userDto = new UserDto("user", "123", "01012345678", UserType.CUSTOMER);
+        User user = new User(userDto);
+
+        when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userService.join(userDto))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    @DisplayName("회원 가입 실패: 중복된 phoneNumber")
+    void join_fail_phoneNumber() {
+        UserDto userDto = new UserDto("user", "123", "01012345678", UserType.CUSTOMER);
+        User user = new User(userDto);
+
+        when(userRepository.findByPhoneNumber("01012345678")).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userService.join(userDto))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    @DisplayName("회원 검색 성공")
+    void search_success() {
+        UserDto userDto = new UserDto("user", "123", "01012345678", UserType.CUSTOMER);
+        User user = new User(userDto);
+
+        when(userRepository.findByUsername(any())).thenReturn(Optional.of(user));
+
+        UserSearchDto userSearchDto = userService.search("user");
+
+        verify(userRepository).findByUsername("user");
+        assertThat(userSearchDto.getUsername()).isEqualTo("user");
+    }
+
+    @Test
+    @DisplayName("회원 검색 실패")
+    void search_fail() {
+        UserDto userDto = new UserDto("user", "123", "01012345678", UserType.CUSTOMER);
+        User user = new User(userDto);
+
+        when(userRepository.findByUsername(any())).thenThrow(NoSuchElementException.class);
+
+        assertThatThrownBy(() -> userService.search("user"))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정 성공")
+    void update_success() {
+        Long id = 1L;
+        UserDto userDto = new UserDto("user", "123", "01012345678", UserType.CUSTOMER);
+
+        User user = mock(User.class);
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+
+        userService.update(id, userDto);
+
+        verify(userRepository).findById(id);
+        verify(user).update(userDto);
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정 실패: 중복된 username")
+    void update_fail_username() {
+        Long id = 1L;
+        UserDto userDto = new UserDto("user", "123", "01012345678", UserType.CUSTOMER);
+        User user = new User(userDto);
+
+        when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userService.update(id, userDto))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    @DisplayName("회원 가입 실패: 중복된 phoneNumber")
+    void update_fail_phoneNumber() {
+        Long id = 1L;
+        UserDto userDto = new UserDto("user", "123", "01012345678", UserType.CUSTOMER);
+        User user = new User(userDto);
+
+        when(userRepository.findByPhoneNumber("01012345678")).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userService.update(id, userDto))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴")
+    void delete() {
+        userService.delete(any());
+        verify(userRepository).deleteById(any());
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

### 디렉토리 설정

도메인 중심 디렉토리 구조를 사용하기로 결정

- common: 여러 도메인이 사용하거나 글로벌하게 쓰이는 기능 패키지별로 분류해서 모아둠 (ex. Config, Exception, Response 등)
- domain: 각 도메인별 패키지를 모아둠 (ex. User, Restaurant 등)

User API부터 작업을 시작했으므로 기존 entity 패키지에서 User 엔티티만 빼서 새 디렉토리 구조를 적용시킴

&nbsp;

### Repository

Spring Data JPA 방식의 UserRepository 인터페이스를 추가함
커스텀 조회 메서드 2개 추가
- findByUsername(): username으로 회원 조회
- findByPhoneNumber(): phoneNumber로 회원 조회

&nbsp;

### Service

UserRepository를 의존성으로 갖는 UserService 클래스를 추가함
- join(): 회원 가입
- search(): 회원 조회
- update(): 회원 정보 수정
- delete(): 회원 정보 삭제 (탈퇴)

회원 가입이나 정보 수정 시, unique 제약이 걸려있는 username과 phoneNumber의 중복을 검증하기 위한 메서드를 구현함
이 때, 회원 정보 수정에서의 검증은 자기 자신의 데이터와 중복으로 인식되지 않도록 함

&nbsp;

### Controller

UserService를 의존성으로 갖는 UserController 클래스를 추가함

응답 타입은 Response라는 커스텀 타입 사용
- 응답 message와 data 2개의 필드 사용

발생 가능한 예외에 대해 ExceptionHandler 메서드 정의

&nbsp;

### 테스트 코드

UserService에 대한 단위 테스트를 작성함
- 외부 의존성은 Mockito로 mocking 하고, 의존성의 동작 방식도 stubbing 해서 순수 로직만 테스트함
- 각 메서드의 성공/실패 케이스를 모두 테스트함

&nbsp;

### 추가 구현 사항

User 엔티티에 UserType enum 필드 추가
- User를 CUSTOMER, OWNER, ADMIN으로 분류
- 추후 Spring Security 적용 시 Authorization에 사용할 예정

User 관련 DTO 추가
- UserDto: 회원 기본 데이터 전용 (username, password, phoneNumber, userType)
- UserSearchDto: 회원 검색 시 조회 가능한 회원 데이터 전용 (username, favorites, reviews)