### PR TITLE
Feature/#5 user api login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
+			'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
 			'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
+++ b/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
@@ -1,0 +1,20 @@
+package com.jvnlee.catchdining.common.advice;
+
+import com.jvnlee.catchdining.common.exception.UserNotFoundException;
+import com.jvnlee.catchdining.common.web.Response;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static org.springframework.http.HttpStatus.*;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    @ExceptionHandler(UserNotFoundException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public Response handleUserNotFound() {
+        return new Response("존재하지 않는 사용자입니다.");
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/common/config/RedisConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.jvnlee.catchdining.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/common/config/SecurityConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.jvnlee.catchdining.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.*;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .httpBasic().disable() // HTTP Basic authentication 사용 안함
+                .csrf().disable() // CSRF protection 사용 안함
+                .sessionManagement().sessionCreationPolicy(STATELESS) // 세션 사용 안함
+                .and()
+                .authorizeHttpRequests()
+                .antMatchers("/users", "/login").permitAll() // 회원가입(POST /users), 로그인(POST /login) URL 접근 허용
+                .anyRequest().authenticated(); // 그 외에는 모두 로그인 후 접근 허용
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder(); // 기본: BcryptPasswordEncoder 제공
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/common/config/SecurityConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/SecurityConfig.java
@@ -1,18 +1,26 @@
 package com.jvnlee.catchdining.common.config;
 
+import com.jvnlee.catchdining.common.filter.JwtAuthenticationFilter;
+import com.jvnlee.catchdining.domain.user.service.JwtService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.*;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtService jwtService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -23,7 +31,10 @@ public class SecurityConfig {
                 .and()
                 .authorizeHttpRequests()
                 .antMatchers("/users", "/login").permitAll() // 회원가입(POST /users), 로그인(POST /login) URL 접근 허용
-                .anyRequest().authenticated(); // 그 외에는 모두 로그인 후 접근 허용
+                .anyRequest().authenticated() // 그 외에는 모두 로그인 후 접근 허용
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter(jwtService),
+                        UsernamePasswordAuthenticationFilter.class); // 모든 AuthentiationFilter 중에 가장 앞에 배치
 
         return http.build();
     }

--- a/src/main/java/com/jvnlee/catchdining/common/config/SecurityConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/SecurityConfig.java
@@ -1,11 +1,12 @@
 package com.jvnlee.catchdining.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jvnlee.catchdining.common.filter.JwtAuthenticationFilter;
+import com.jvnlee.catchdining.common.filter.JwtExceptionFilter;
 import com.jvnlee.catchdining.domain.user.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
@@ -22,6 +23,8 @@ public class SecurityConfig {
 
     private final JwtService jwtService;
 
+    private final ObjectMapper om;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -34,7 +37,9 @@ public class SecurityConfig {
                 .anyRequest().authenticated() // 그 외에는 모두 로그인 후 접근 허용
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtService),
-                        UsernamePasswordAuthenticationFilter.class); // 모든 AuthentiationFilter 중에 가장 앞에 배치
+                        UsernamePasswordAuthenticationFilter.class) // 모든 AuthentiationFilter 중에 가장 앞에 배치
+                .addFilterBefore(new JwtExceptionFilter(om),
+                        JwtAuthenticationFilter.class); // JwtAuthenticationFilter에서 예외가 발생하면 처리해줄 필터 배치
 
         return http.build();
     }

--- a/src/main/java/com/jvnlee/catchdining/common/config/SecurityConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/SecurityConfig.java
@@ -3,10 +3,12 @@ package com.jvnlee.catchdining.common.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jvnlee.catchdining.common.filter.JwtAuthenticationFilter;
 import com.jvnlee.catchdining.common.filter.JwtExceptionFilter;
+import com.jvnlee.catchdining.domain.user.repository.UserRepository;
 import com.jvnlee.catchdining.domain.user.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
@@ -25,6 +27,11 @@ public class SecurityConfig {
 
     private final ObjectMapper om;
 
+    private final UserRepository userRepository;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -36,7 +43,7 @@ public class SecurityConfig {
                 .antMatchers("/users", "/login").permitAll() // 회원가입(POST /users), 로그인(POST /login) URL 접근 허용
                 .anyRequest().authenticated() // 그 외에는 모두 로그인 후 접근 허용
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtService),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtService, userRepository, redisTemplate),
                         UsernamePasswordAuthenticationFilter.class) // 모든 AuthentiationFilter 중에 가장 앞에 배치
                 .addFilterBefore(new JwtExceptionFilter(om),
                         JwtAuthenticationFilter.class); // JwtAuthenticationFilter에서 예외가 발생하면 처리해줄 필터 배치

--- a/src/main/java/com/jvnlee/catchdining/common/exception/UserNotFoundException.java
+++ b/src/main/java/com/jvnlee/catchdining/common/exception/UserNotFoundException.java
@@ -1,0 +1,4 @@
+package com.jvnlee.catchdining.common.exception;
+
+public class UserNotFoundException extends RuntimeException {
+}

--- a/src/main/java/com/jvnlee/catchdining/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/jvnlee/catchdining/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,81 @@
+package com.jvnlee.catchdining.common.filter;
+
+import com.jvnlee.catchdining.domain.user.service.JwtService;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+import static org.springframework.http.HttpHeaders.*;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final JwtService jwtService;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+
+        // Authorization 헤더가 없으면 그대로 doFilter() 호출해서 건너뜀 (회원가입이 안된 경우, 최초 로그인한 경우, 토큰이 모두 만료되어 재로그인한 경우)
+        if (req.getHeader(AUTHORIZATION) == null || req.getHeader(AUTHORIZATION).isEmpty()) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String[] authHeader = req.getHeader(AUTHORIZATION).split(" ");
+
+        // "Bearer [Access Token] [Refresh Token]" 3단 구조인지 체크
+        if (authHeader.length != 3) {
+            throw new IllegalArgumentException("Authorization header의 형식이 올바르지 않습니다.");
+        }
+
+        String scheme = authHeader[0];
+
+        // scheme이 "Bearer"인지 검증
+        if (!jwtService.validateScheme(scheme)) {
+            throw new IllegalArgumentException("Authorization header의 scheme이 올바르지 않습니다.");
+        }
+
+        String accessToken = authHeader[1];
+
+        // Access Token이 유효한지 검증, 유효하면 인증 처리하고 doFilter
+        if (jwtService.validateToken(accessToken)) {
+            authenticate(accessToken);
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String refreshToken = authHeader[2];
+
+        // Access Token은 유효하지 않은데, Refresh Token은 유효한 경우 Access Token 재발급
+        if (jwtService.validateToken(refreshToken)) {
+            try {
+                // 만료된 Access Token으로부터 Authentication 정보 추출 시도
+                Authentication authentication = jwtService.getAuthentication(accessToken);
+                String newAccessToken = jwtService.createAccessToken(authentication);
+                authenticate(newAccessToken);
+            } catch (JwtException e) {
+                // 인증 정보 추출에 실패 시, 재로그인해서 Access Token과 Refresh Token 모두 새로 발급 받아야함
+                throw new IllegalArgumentException("올바르지 않은 토큰입니다. 인증 정보를 불러올 수 없습니다.");
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private void authenticate(String accessToken) {
+        SecurityContextHolder
+                .getContext()
+                .setAuthentication(jwtService.getAuthentication(accessToken));
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/common/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/jvnlee/catchdining/common/filter/JwtExceptionFilter.java
@@ -1,0 +1,36 @@
+package com.jvnlee.catchdining.common.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jvnlee.catchdining.common.web.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static javax.servlet.http.HttpServletResponse.*;
+import static org.springframework.http.MediaType.*;
+
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends GenericFilterBean {
+
+    private final ObjectMapper om;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        try {
+            chain.doFilter(request, response);
+        } catch (Exception e) {
+            HttpServletResponse res = (HttpServletResponse) response;
+            res.setStatus(SC_BAD_REQUEST);
+            res.setContentType(APPLICATION_JSON_VALUE);
+            res.setCharacterEncoding("UTF-8");
+            om.writeValue(res.getWriter(), new Response<>(e.getMessage()));
+        }
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserController.java
@@ -9,8 +9,6 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.NoSuchElementException;
-
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
@@ -46,12 +44,6 @@ public class UserController {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Response handleDuplicateData(DuplicateKeyException e) {
         return new Response(e.getMessage());
-    }
-
-    @ExceptionHandler(NoSuchElementException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public Response handleNoData() {
-        return new Response("해당 username을 가진 사용자가 존재하지 않습니다.");
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserLoginController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserLoginController.java
@@ -1,0 +1,24 @@
+package com.jvnlee.catchdining.domain.user.controller;
+
+import com.jvnlee.catchdining.common.web.Response;
+import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
+import com.jvnlee.catchdining.domain.user.service.UserLoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/login")
+@RequiredArgsConstructor
+public class UserLoginController {
+
+    private final UserLoginService userLoginService;
+
+    @PostMapping
+    public Response login(UserLoginDto userLoginDto) {
+        userLoginService.login(userLoginDto);
+        return new Response("로그인 성공");
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserLoginController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserLoginController.java
@@ -5,6 +5,8 @@ import com.jvnlee.catchdining.domain.user.dto.JwtDto;
 import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
 import com.jvnlee.catchdining.domain.user.service.UserLoginService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -23,6 +25,12 @@ public class UserLoginController {
         JwtDto jwtDto = userLoginService.login(userLoginDto);
         response.setHeader(AUTHORIZATION, "Bearer " + jwtDto.getAccessToken() + " " + jwtDto.getRefreshToken());
         return new Response("로그인 성공");
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response handleBadCredentials() {
+        return new Response("비밀번호가 올바르지 않습니다.");
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserLoginController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserLoginController.java
@@ -1,12 +1,15 @@
 package com.jvnlee.catchdining.domain.user.controller;
 
 import com.jvnlee.catchdining.common.web.Response;
+import com.jvnlee.catchdining.domain.user.dto.JwtDto;
 import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
 import com.jvnlee.catchdining.domain.user.service.UserLoginService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static org.springframework.http.HttpHeaders.*;
 
 @RestController
 @RequestMapping("/login")
@@ -16,8 +19,9 @@ public class UserLoginController {
     private final UserLoginService userLoginService;
 
     @PostMapping
-    public Response login(UserLoginDto userLoginDto) {
-        userLoginService.login(userLoginDto);
+    public Response login(UserLoginDto userLoginDto, HttpServletResponse response) {
+        JwtDto jwtDto = userLoginService.login(userLoginDto);
+        response.setHeader(AUTHORIZATION, "Bearer " + jwtDto.getAccessToken() + " " + jwtDto.getRefreshToken());
         return new Response("로그인 성공");
     }
 

--- a/src/main/java/com/jvnlee/catchdining/domain/user/dto/JwtDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/dto/JwtDto.java
@@ -1,0 +1,14 @@
+package com.jvnlee.catchdining.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtDto {
+
+    private String accessToken;
+
+    private String refreshToken;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserLoginDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserLoginDto.java
@@ -1,0 +1,12 @@
+package com.jvnlee.catchdining.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class UserLoginDto {
+
+    private String username;
+
+    private String password;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
@@ -4,10 +4,14 @@ import com.jvnlee.catchdining.domain.user.dto.UserDto;
 import com.jvnlee.catchdining.entity.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static javax.persistence.GenerationType.*;
@@ -16,7 +20,7 @@ import static lombok.AccessLevel.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class User extends BaseEntity {
+public class User extends BaseEntity implements UserDetails {
 
     @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "user_id")
@@ -56,6 +60,31 @@ public class User extends BaseEntity {
         this.username = userDto.getUsername();
         this.password = userDto.getPassword();
         this.phoneNumber = userDto.getPhoneNumber();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + this.userType.toString()));
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/JwtService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/JwtService.java
@@ -91,6 +91,10 @@ public class JwtService {
         }
     }
 
+    public Long getRefreshExp() {
+        return this.REFRESH_EXP;
+    }
+
     private String getAuthoritiesString(Authentication authentication) {
         return authentication
                 .getAuthorities()

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/JwtService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/JwtService.java
@@ -1,0 +1,118 @@
+package com.jvnlee.catchdining.domain.user.service;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.jsonwebtoken.io.Decoders.*;
+
+@Service
+public class JwtService {
+
+    private final Key SECRET_KEY;
+
+    private final SignatureAlgorithm SIG_ALG;
+
+    private final Long ACCESS_EXP;
+
+    private final Long REFRESH_EXP;
+
+    public JwtService(@Value("${jwt.secret}") String secretKey,
+                      @Value("${jwt.alg}") String sigAlg,
+                      @Value("${jwt.access.exp}") Long accessExp,
+                      @Value("${jwt.refresh.exp}") Long refreshExp) {
+        this.SECRET_KEY = Keys.hmacShaKeyFor(BASE64.decode(secretKey));
+        this.SIG_ALG = SignatureAlgorithm.forName(sigAlg);
+        this.ACCESS_EXP = accessExp;
+        this.REFRESH_EXP = refreshExp;
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        String username = authentication.getName();
+        String authorities = getAuthoritiesString(authentication);
+
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(getExpDate(ACCESS_EXP))
+                .claim("auth", authorities)
+                .signWith(SECRET_KEY, SIG_ALG)
+                .compact();
+    }
+
+    public String createRefreshToken() {
+        return Jwts.builder()
+                .setIssuedAt(new Date())
+                .setExpiration(getExpDate(REFRESH_EXP))
+                .signWith(SECRET_KEY, SIG_ALG)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = getClaims(token);
+
+        if (claims.getSubject() == null) {
+            throw new MalformedJwtException("토큰에 subject 정보가 존재하지 않습니다.");
+        }
+
+        if (claims.get("auth") == null) {
+            throw new MalformedJwtException("토큰에 authorities 정보가 존재하지 않습니다.");
+        }
+
+        String username = claims.getSubject();
+        List<SimpleGrantedAuthority> authorities = getAuthoritiesList(claims);
+        return new UsernamePasswordAuthenticationToken(username, null, authorities);
+    }
+
+    public boolean validateScheme(String scheme) {
+        return scheme.equals("Bearer");
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(SECRET_KEY)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    private String getAuthoritiesString(Authentication authentication) {
+        return authentication
+                .getAuthorities()
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+    }
+
+    private List<SimpleGrantedAuthority> getAuthoritiesList(Claims claims) {
+        return Arrays.stream(claims.get("auth").toString().split(",")).map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+
+    private Date getExpDate(Long expIn) {
+        return new Date(System.currentTimeMillis() + expIn);
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(SECRET_KEY)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserLoginService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserLoginService.java
@@ -46,8 +46,8 @@ public class UserLoginService implements UserDetailsService {
         Authentication auth = authenticationManagerBuilder.getObject().authenticate(authToken);
 
         // 인증에 성공하면 JWT 생성
-        String accessToken = jwtService.createAccessToken(auth);
-        String refreshToken = jwtService.createRefreshToken();
+        String accessToken = jwtService.createAccessToken(username, user.getAuthorities());
+        String refreshToken = jwtService.createRefreshToken(user.getId());
 
         // Refresh Token을 Redis에 저장
         redisTemplate.opsForValue().set(

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserLoginService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserLoginService.java
@@ -1,0 +1,48 @@
+package com.jvnlee.catchdining.domain.user.service;
+
+import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
+import com.jvnlee.catchdining.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserLoginService implements UserDetailsService {
+
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    private final UserRepository userRepository;
+
+    public void login(UserLoginDto userLoginDto) {
+        String username = userLoginDto.getUsername();
+        String password = userLoginDto.getPassword();
+        Collection<? extends GrantedAuthority> authorities = userRepository.findByUsername(username).orElseThrow().getAuthorities();
+
+        // 인증 토큰 생성 (username, password, authorities)
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, authorities);
+
+        // AuthenticationManager에게 인증 토큰을 넘겨 인증 진행
+        Authentication auth = authenticationManagerBuilder.getObject().authenticate(authToken);
+
+        // 인증을 마친 Authentication 객체를 SecurityContextHolder에 보관
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUsername(username).orElseThrow();
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserLoginService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserLoginService.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.domain.user.service;
 
+import com.jvnlee.catchdining.domain.user.dto.JwtDto;
 import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
 import com.jvnlee.catchdining.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +26,9 @@ public class UserLoginService implements UserDetailsService {
 
     private final UserRepository userRepository;
 
-    public void login(UserLoginDto userLoginDto) {
+    private final JwtService jwtService;
+
+    public JwtDto login(UserLoginDto userLoginDto) {
         String username = userLoginDto.getUsername();
         String password = userLoginDto.getPassword();
         Collection<? extends GrantedAuthority> authorities = userRepository.findByUsername(username).orElseThrow().getAuthorities();
@@ -36,8 +39,14 @@ public class UserLoginService implements UserDetailsService {
         // AuthenticationManager에게 인증 토큰을 넘겨 인증 진행
         Authentication auth = authenticationManagerBuilder.getObject().authenticate(authToken);
 
+        // 인증에 성공하면 JWT 생성
+        String accessToken = jwtService.createAccessToken(auth);
+        String refreshToken = jwtService.createRefreshToken();
+
         // 인증을 마친 Authentication 객체를 SecurityContextHolder에 보관
         SecurityContextHolder.getContext().setAuthentication(auth);
+
+        return new JwtDto(accessToken, refreshToken);
     }
 
     @Override

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserLoginService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserLoginService.java
@@ -3,12 +3,13 @@ package com.jvnlee.catchdining.domain.user.service;
 import com.jvnlee.catchdining.common.exception.UserNotFoundException;
 import com.jvnlee.catchdining.domain.user.dto.JwtDto;
 import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
+import com.jvnlee.catchdining.domain.user.model.User;
 import com.jvnlee.catchdining.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -16,7 +17,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
+import static java.util.concurrent.TimeUnit.*;
 
 @Service
 @Transactional
@@ -29,16 +30,17 @@ public class UserLoginService implements UserDetailsService {
 
     private final JwtService jwtService;
 
+    private final RedisTemplate<String, String> redisTemplate;
+
     public JwtDto login(UserLoginDto userLoginDto) {
         String username = userLoginDto.getUsername();
         String password = userLoginDto.getPassword();
-        Collection<? extends GrantedAuthority> authorities = userRepository
+        User user = userRepository
                 .findByUsername(username)
-                .orElseThrow(UserNotFoundException::new)
-                .getAuthorities();
+                .orElseThrow(UserNotFoundException::new);
 
         // 인증 토큰 생성 (username, password, authorities)
-        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, authorities);
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, user.getAuthorities());
 
         // AuthenticationManager에게 인증 토큰을 넘겨 인증 진행
         Authentication auth = authenticationManagerBuilder.getObject().authenticate(authToken);
@@ -46,6 +48,14 @@ public class UserLoginService implements UserDetailsService {
         // 인증에 성공하면 JWT 생성
         String accessToken = jwtService.createAccessToken(auth);
         String refreshToken = jwtService.createRefreshToken();
+
+        // Refresh Token을 Redis에 저장
+        redisTemplate.opsForValue().set(
+                user.getId().toString(),
+                refreshToken,
+                jwtService.getRefreshExp(),
+                MILLISECONDS
+        );
 
         // 인증을 마친 Authentication 객체를 SecurityContextHolder에 보관
         SecurityContextHolder.getContext().setAuthentication(auth);

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserLoginService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserLoginService.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.domain.user.service;
 
+import com.jvnlee.catchdining.common.exception.UserNotFoundException;
 import com.jvnlee.catchdining.domain.user.dto.JwtDto;
 import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
 import com.jvnlee.catchdining.domain.user.repository.UserRepository;
@@ -31,7 +32,10 @@ public class UserLoginService implements UserDetailsService {
     public JwtDto login(UserLoginDto userLoginDto) {
         String username = userLoginDto.getUsername();
         String password = userLoginDto.getPassword();
-        Collection<? extends GrantedAuthority> authorities = userRepository.findByUsername(username).orElseThrow().getAuthorities();
+        Collection<? extends GrantedAuthority> authorities = userRepository
+                .findByUsername(username)
+                .orElseThrow(UserNotFoundException::new)
+                .getAuthorities();
 
         // 인증 토큰 생성 (username, password, authorities)
         UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, authorities);
@@ -51,7 +55,9 @@ public class UserLoginService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return userRepository.findByUsername(username).orElseThrow();
+        return userRepository
+                .findByUsername(username)
+                .orElseThrow(UserNotFoundException::new);
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.domain.user.service;
 
+import com.jvnlee.catchdining.common.exception.UserNotFoundException;
 import com.jvnlee.catchdining.domain.user.dto.UserDto;
 import com.jvnlee.catchdining.domain.user.dto.UserSearchDto;
 import com.jvnlee.catchdining.domain.user.model.User;
@@ -33,7 +34,9 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserSearchDto search(String username) {
-        User user = userRepository.findByUsername(username).orElseThrow();
+        User user = userRepository
+                .findByUsername(username)
+                .orElseThrow(UserNotFoundException::new);
         return new UserSearchDto(user);
     }
 

--- a/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.jvnlee.catchdining.domain.user.model.User;
 import com.jvnlee.catchdining.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,9 +19,14 @@ public class UserService {
 
     private final UserRepository userRepository;
 
+    private final PasswordEncoder passwordEncoder;
+
     public void join(UserDto userDto) {
         validateUsername(userDto);
         validatePhoneNumber(userDto);
+
+        encodePassword(userDto);
+
         User newUser = new User(userDto);
         userRepository.save(newUser);
     }
@@ -34,6 +40,9 @@ public class UserService {
     public void update(Long id, UserDto userDto) {
         validateUsername(id, userDto);
         validatePhoneNumber(id, userDto);
+
+        encodePassword(userDto);
+
         User user = userRepository.findById(id).orElseThrow();
         user.update(userDto);
     }
@@ -68,6 +77,11 @@ public class UserService {
             if (user.get().getId().equals(id)) return; // 같은 phoneNumber 가진 기존 데이터가 자기 자신인 경우는 패스
             throw new DuplicateKeyException("이미 존재하는 연락처입니다.");
         }
+    }
+
+    private void encodePassword(UserDto userDto) {
+        String encodedPassword = passwordEncoder.encode(userDto.getPassword());
+        userDto.setPassword(encodedPassword);
     }
 
 }


### PR DESCRIPTION
## 구현 내용

### Spring Security 도입

SecurityConfig 클래스
- 회원 가입(POST /users)과 로그인(POST /login) 경로를 인증/인가 제한 없이 허용
- 그 외의 경로는 모두 인증/인가가 완료된 User만 접근할 수 있게 설정
- JWT를 포함한 요청이 들어오면 처리할 수 있도록 JwtAuthenticationFilter를 필터 체인에 등록
- JWT 처리 도중 발생할 수 있는 예외를 처리하는 JwtExceptionFilter를 필터 체인에 등록
- PasswordEncoder Bean 등록 (DelegatingPasswordEncoder: 기본적으로 BcryptPasswordEncoder 사용)

기존 UserService의 join()과 update()에 PasswordEncoder를 사용한 password encoding 로직 추가

&nbsp;

### UserDetails, UserDetailsService

Spring Security의 인증/인가 처리에 필요한 UserDetails와 UserDetailsService 도입

- UserDetails: 기존 User 엔티티가 구현하도록 함
- UserDetailsService: UserLoginService가 구현하도록 함

&nbsp;

### JwtAuthenticationFilter

#### 📌 Case 1) JWT 없이 최초 로그인하는 사용자

POST /login 경로로 username과 password를 보냄
- 로그인 성공: JWT Access Token과 Refresh Token 발급
- 로그인 실패: UserNotFoundException 또는 BadCredentialsException이 발생

UserLoginController &#8594; UserLoginService 의 과정을 거쳐 로그인 처리 (JwtAuthenticationFilter의 로직은 건너뜀)

#### 📌 Case 2) JWT를 가지고 인증/인가를 요청하는 사용자

JwtAuthenticationFilter에서 검증 로직을 거침

HTTP Authorization 헤더에 아래와 같은 정상적인 양식으로 요청했는지 검증
ex) Authorization: Bearer [AccessToken] [Refresh Token]
> Resource 서버와 Authorization 서버가 분리되어 있지 않기 때문에 Refresh Token도 항상 포함시키도록 함

Authorization 헤더가 정상인 경우, JWT 토큰 검증
| # | Access | Refresh | |
|-----|-----|-----|-----|
| 1 | Valid | Valid | 정상 로그인 처리 |
| 2 | Valid | Invalid | Refresh Token의 유효 여부와 관계 없이 정상 로그인 처리 |
| 3 | Invalid | Valid | Refresh Token 검증 후 Access Token 재발급 |
| 4 | Invalid | Invalid | username과 password로 재로그인 필요 |

> 2번의 경우, 추후 Access Token이 만료되면 Refresh Token이 Invalid 하기 때문에 4번과 동일 (재로그인 필요)
> 
> 3번의 경우, Access Token이 아예 잘못된 형식인 경우 Claims로부터 정보 추출이 불가능하므로 4번과 동일 (재로그인 필요)

JWT를 통해 인증/인가가 완료된 경우, UserLoginController와 UserLoginService를 거치지 않고도 리소스 접근 가능

&nbsp;

### JwtService

보안이 필요한 데이터는 application.properties 를 통해서 별도 관리 (gitignore)
> secret key, signature algorithm, access/refresh token의 expiration 기한

jjwt 라이브러리에서 제공하는 기능으로 JWT 관련 기능 수행

- createAccessToken(): username과 authorities를 파라미터로 받아와 Access Token 생성
- createRefreshToken(): id를 파라미터로 받아와 Refresh Token 생성
- getAuthentication(): Access Token을 파라미터로 받아와 claims 데이터 추출 후 Authentication 인스턴스 반환
- validateScheme(): HTTP Authorization 헤더의 authorization scheme이 Bearer인지 검증
- validateToken(): secret key를 가지고 정상적으로 서명된 토큰인지 검증

> JWT Refresh Token 생성 정책
>
> 기본적으로 Refresh Token에는 민감한 데이터를 포함시키면 안되고, Refresh 용도로만 사용할 수 있게 최대한 가볍게 만들어야함.
> 그러나 Access Token 재발급하는 상황에 내부적으로 발급 대상을 특정할 수 있어야하기 때문에 User의 id를 Refresh Token에 포함시키기로 결정함. id는 외부에 노출되어도 이 값만을 가지고 직접적으로 보안 데이터를 유추하거나 그런 데이터에 접근할 수 있는 수단이 되지 않는다고 판단함.

&nbsp;

### Redis 도입

서버에서 Refresh Token 값을 보관하는 수단으로 사용

RedisTemplate을 Bean으로 등록해서 사용함
- Key: User의 id 문자열
- Value: Refresh Token 문자열

JWT 없이 username과 password로 로그인하는 사용자가 인증에 성공하면 Access Token과 Refresh Token을 발급하고 Refresh Token만 Redis에 저장함.

JWT가 포함된 요청이 들어왔을 때, 앞서 언급되었던 3번의 경우 Refresh Token 자체의 유효성도 검증하지만, 해당 토큰이 Redis에 저장된 (즉, 서버가 알고 있는 가장 최신의) 토큰인지 비교하여 확인하는 과정을 거침.