### PR TITLE
feature/#16 seat api crud

### DIFF
--- a/src/main/java/com/jvnlee/catchdining/CatchdiningApplication.java
+++ b/src/main/java/com/jvnlee/catchdining/CatchdiningApplication.java
@@ -3,9 +3,11 @@ package com.jvnlee.catchdining;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class CatchdiningApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
+++ b/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.common.advice;
 
+import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
 import com.jvnlee.catchdining.common.exception.UserNotFoundException;
 import com.jvnlee.catchdining.common.web.Response;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,6 +16,12 @@ public class ControllerAdvice {
     @ResponseStatus(NOT_FOUND)
     public Response handleUserNotFound() {
         return new Response("존재하지 않는 사용자입니다.");
+    }
+
+    @ExceptionHandler(RestaurantNotFoundException.class)
+    @ResponseStatus(NOT_FOUND)
+    public Response<Void> handleRestaurantNotFound() {
+        return new Response<>("식당 정보가 존재하지 않습니다.");
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/common/exception/SeatNotFoundException.java
+++ b/src/main/java/com/jvnlee/catchdining/common/exception/SeatNotFoundException.java
@@ -1,0 +1,4 @@
+package com.jvnlee.catchdining.common.exception;
+
+public class SeatNotFoundException extends RuntimeException {
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/controller/RestaurantController.java
@@ -61,10 +61,4 @@ public class RestaurantController {
         return new Response<>(e.getMessage());
     }
 
-    @ExceptionHandler(RestaurantNotFoundException.class)
-    @ResponseStatus(NOT_FOUND)
-    public Response<Void> handleRestaurantNotFound() {
-        return new Response<>("식당 정보가 존재하지 않습니다.");
-    }
-
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/model/Restaurant.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/model/Restaurant.java
@@ -1,6 +1,7 @@
 package com.jvnlee.catchdining.domain.restaurant.model;
 
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantDto;
+import com.jvnlee.catchdining.domain.seat.model.Seat;
 import com.jvnlee.catchdining.entity.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/controller/SeatController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/controller/SeatController.java
@@ -1,0 +1,47 @@
+package com.jvnlee.catchdining.domain.seat.controller;
+
+import com.jvnlee.catchdining.common.exception.SeatNotFoundException;
+import com.jvnlee.catchdining.common.web.Response;
+import com.jvnlee.catchdining.domain.seat.dto.SeatDto;
+import com.jvnlee.catchdining.domain.seat.dto.SeatSearchDto;
+import com.jvnlee.catchdining.domain.seat.model.SeatType;
+import com.jvnlee.catchdining.domain.seat.service.SeatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
+
+@RestController
+@RequestMapping("/restaurants/{restaurantId}/seats")
+@RequiredArgsConstructor
+public class SeatController {
+
+    private final SeatService seatService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ROLE_OWNER')")
+    public Response<Void> add(@PathVariable Long restaurantId, @RequestBody SeatDto seatDto) {
+        seatService.add(restaurantId, seatDto);
+        return new Response<>("자리 등록 성공");
+    }
+
+    @GetMapping
+    public Response<List<SeatSearchDto>> search(@PathVariable Long restaurantId,
+                                                @RequestParam @DateTimeFormat(iso = DATE) LocalDate date,
+                                                @RequestParam SeatType seatType,
+                                                @RequestParam int headCount) {
+        List<SeatSearchDto> data = seatService.search(restaurantId, date, seatType, headCount);
+        return new Response<>("예약 가능 목록 조회 결과", data);
+    }
+
+    @ExceptionHandler(SeatNotFoundException.class)
+    public Response<Void> handleSeatNotFound() {
+        return new Response<>("자리 정보가 존재하지 않습니다.");
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/controller/SeatController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/controller/SeatController.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
+import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequestMapping("/restaurants/{restaurantId}/seats")
@@ -40,6 +41,7 @@ public class SeatController {
     }
 
     @ExceptionHandler(SeatNotFoundException.class)
+    @ResponseStatus(NOT_FOUND)
     public Response<Void> handleSeatNotFound() {
         return new Response<>("자리 정보가 존재하지 않습니다.");
     }

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/dto/SeatDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/dto/SeatDto.java
@@ -1,0 +1,22 @@
+package com.jvnlee.catchdining.domain.seat.dto;
+
+import com.jvnlee.catchdining.domain.seat.model.SeatType;
+import lombok.Data;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Data
+public class SeatDto {
+
+    private SeatType seatType;
+
+    private List<LocalTime> availableTimes;
+
+    private int maxHeadCount;
+
+    private int quantity;
+
+    private int availableQuantity;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/dto/SeatDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/dto/SeatDto.java
@@ -1,22 +1,24 @@
 package com.jvnlee.catchdining.domain.seat.dto;
 
 import com.jvnlee.catchdining.domain.seat.model.SeatType;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.time.LocalTime;
 import java.util.List;
 
 @Data
+@AllArgsConstructor
 public class SeatDto {
 
     private SeatType seatType;
 
     private List<LocalTime> availableTimes;
 
+    private int minHeadCount;
+
     private int maxHeadCount;
 
     private int quantity;
-
-    private int availableQuantity;
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/dto/SeatSearchDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/dto/SeatSearchDto.java
@@ -1,0 +1,18 @@
+package com.jvnlee.catchdining.domain.seat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeatSearchDto {
+
+    private Long seatId;
+
+    private LocalTime time;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/model/Seat.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/model/Seat.java
@@ -1,7 +1,6 @@
 package com.jvnlee.catchdining.domain.seat.model;
 
 import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
-import com.jvnlee.catchdining.domain.seat.dto.SeatDto;
 import com.jvnlee.catchdining.entity.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,6 +38,8 @@ public class Seat extends BaseEntity {
     private LocalDate availableDate;
 
     private LocalTime availableTime;
+
+    private int minHeadCount;
 
     private int maxHeadCount;
 

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/model/Seat.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/model/Seat.java
@@ -1,6 +1,7 @@
-package com.jvnlee.catchdining.entity;
+package com.jvnlee.catchdining.domain.seat.model;
 
 import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
+import com.jvnlee.catchdining.entity.BaseEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,7 +35,7 @@ public class Seat extends BaseEntity {
     @ElementCollection
     @CollectionTable(name = "available_time",
             joinColumns = @JoinColumn(name = "seat_id"))
-    private List<LocalDateTime> availabeTime = new ArrayList<>();
+    private List<LocalDateTime> availableTime = new ArrayList<>();
 
     private int maxHeadCount;
 

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/model/Seat.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/model/Seat.java
@@ -1,15 +1,17 @@
 package com.jvnlee.catchdining.domain.seat.model;
 
 import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
+import com.jvnlee.catchdining.domain.seat.dto.SeatDto;
 import com.jvnlee.catchdining.entity.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -17,7 +19,9 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
 public class Seat extends BaseEntity {
 
     @Id
@@ -32,11 +36,14 @@ public class Seat extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SeatType seatType;
 
-    @ElementCollection
-    @CollectionTable(name = "available_time",
-            joinColumns = @JoinColumn(name = "seat_id"))
-    private List<LocalDateTime> availableTime = new ArrayList<>();
+    private LocalDate availableDate;
+
+    private LocalTime availableTime;
 
     private int maxHeadCount;
+
+    private int quantity;
+
+    private int availableQuantity;
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/model/SeatType.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/model/SeatType.java
@@ -1,0 +1,5 @@
+package com.jvnlee.catchdining.domain.seat.model;
+
+public enum SeatType {
+    HALL, ROOM, BAR
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/repository/SeatRepository.java
@@ -17,7 +17,7 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
             "where s.restaurant.id = :restaurantId " +
             "and s.availableDate = :date " +
             "and s.seatType = :seatType " +
-            "and s.maxHeadCount >= :headCount")
+            "and :headCount between s.minHeadCount and s.maxHeadCount")
     List<SeatSearchDto> findTimeByCond(Long restaurantId, LocalDate date, SeatType seatType, int headCount);
 
     @Modifying

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/repository/SeatRepository.java
@@ -1,7 +1,22 @@
 package com.jvnlee.catchdining.domain.seat.repository;
 
+import com.jvnlee.catchdining.domain.seat.dto.SeatSearchDto;
 import com.jvnlee.catchdining.domain.seat.model.Seat;
+import com.jvnlee.catchdining.domain.seat.model.SeatType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
+
+    @Query("select new com.jvnlee.catchdining.domain.seat.dto.SeatSearchDto(s.id, s.availableTime) " +
+            "from Seat s " +
+            "where s.restaurant.id = :restaurantId " +
+            "and s.availableDate = :date " +
+            "and s.seatType = :seatType " +
+            "and s.maxHeadCount >= :headCount")
+    List<SeatSearchDto> findTimeByCond(Long restaurantId, LocalDate date, SeatType seatType, int headCount);
+
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/repository/SeatRepository.java
@@ -4,6 +4,7 @@ import com.jvnlee.catchdining.domain.seat.dto.SeatSearchDto;
 import com.jvnlee.catchdining.domain.seat.model.Seat;
 import com.jvnlee.catchdining.domain.seat.model.SeatType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
@@ -18,5 +19,12 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
             "and s.seatType = :seatType " +
             "and s.maxHeadCount >= :headCount")
     List<SeatSearchDto> findTimeByCond(Long restaurantId, LocalDate date, SeatType seatType, int headCount);
+
+    @Modifying
+    @Query("update Seat s " +
+            "set s.availableDate = :date, " +
+            "s.availableQuantity = s.quantity " +
+            "where s.availableDate < :today")
+    void updatePastDates(LocalDate date, LocalDate today);
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/repository/SeatRepository.java
@@ -1,0 +1,7 @@
+package com.jvnlee.catchdining.domain.seat.repository;
+
+import com.jvnlee.catchdining.domain.seat.model.Seat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/service/SeatService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/service/SeatService.java
@@ -10,6 +10,7 @@ import com.jvnlee.catchdining.domain.seat.model.Seat;
 import com.jvnlee.catchdining.domain.seat.model.SeatType;
 import com.jvnlee.catchdining.domain.seat.repository.SeatRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +57,11 @@ public class SeatService {
         List<SeatSearchDto> result = seatRepository.findTimeByCond(restaurantId, date, seatType, headCount);
         if (result.isEmpty()) throw new SeatNotFoundException();
         return result;
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void updatePastDates() {
+        seatRepository.updatePastDates(LocalDate.now().plusDays(RESERVABLE_DATE_LIMIT - 1), LocalDate.now());
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/service/SeatService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/service/SeatService.java
@@ -43,9 +43,10 @@ public class SeatService {
                         .seatType(seatDto.getSeatType())
                         .availableDate(LocalDate.now().plusDays(i))
                         .availableTime(availableTime)
+                        .minHeadCount(seatDto.getMinHeadCount())
                         .maxHeadCount(seatDto.getMaxHeadCount())
                         .quantity(seatDto.getQuantity())
-                        .availableQuantity(seatDto.getAvailableQuantity())
+                        .availableQuantity(seatDto.getQuantity())
                         .build();
 
                 seatRepository.save(seat);

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/service/SeatService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/service/SeatService.java
@@ -1,0 +1,61 @@
+package com.jvnlee.catchdining.domain.seat.service;
+
+import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
+import com.jvnlee.catchdining.common.exception.SeatNotFoundException;
+import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
+import com.jvnlee.catchdining.domain.restaurant.repository.RestaurantRepository;
+import com.jvnlee.catchdining.domain.seat.dto.SeatDto;
+import com.jvnlee.catchdining.domain.seat.dto.SeatSearchDto;
+import com.jvnlee.catchdining.domain.seat.model.Seat;
+import com.jvnlee.catchdining.domain.seat.model.SeatType;
+import com.jvnlee.catchdining.domain.seat.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SeatService {
+
+    private final SeatRepository seatRepository;
+
+    private final RestaurantRepository restaurantRepository;
+
+    private final int RESERVABLE_DATE_LIMIT = 7;
+
+    public void add(Long restaurantId, SeatDto seatDto) {
+        Restaurant restaurant = restaurantRepository
+                .findById(restaurantId)
+                .orElseThrow(RestaurantNotFoundException::new);
+
+        List<LocalTime> availableTimes = seatDto.getAvailableTimes();
+
+        for (LocalTime availableTime : availableTimes) {
+            for (int i = 0; i < RESERVABLE_DATE_LIMIT; i++) {
+                Seat seat = Seat.builder()
+                        .restaurant(restaurant)
+                        .seatType(seatDto.getSeatType())
+                        .availableDate(LocalDate.now().plusDays(i))
+                        .availableTime(availableTime)
+                        .maxHeadCount(seatDto.getMaxHeadCount())
+                        .quantity(seatDto.getQuantity())
+                        .availableQuantity(seatDto.getAvailableQuantity())
+                        .build();
+
+                seatRepository.save(seat);
+            }
+        }
+    }
+
+    public List<SeatSearchDto> search(Long restaurantId, LocalDate date, SeatType seatType, int headCount) {
+        List<SeatSearchDto> result = seatRepository.findTimeByCond(restaurantId, date, seatType, headCount);
+        if (result.isEmpty()) throw new SeatNotFoundException();
+        return result;
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/entity/Reservation.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Reservation.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.entity;
 
+import com.jvnlee.catchdining.domain.seat.model.Seat;
 import com.jvnlee.catchdining.domain.user.model.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/jvnlee/catchdining/entity/SeatType.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/SeatType.java
@@ -1,5 +1,0 @@
-package com.jvnlee.catchdining.entity;
-
-public enum SeatType {
-    HALL, ROOM, BAR
-}

--- a/src/test/java/com/jvnlee/catchdining/domain/seat/controller/SeatControllerTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/seat/controller/SeatControllerTest.java
@@ -1,0 +1,130 @@
+package com.jvnlee.catchdining.domain.seat.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jvnlee.catchdining.common.exception.SeatNotFoundException;
+import com.jvnlee.catchdining.domain.seat.dto.SeatDto;
+import com.jvnlee.catchdining.domain.seat.dto.SeatSearchDto;
+import com.jvnlee.catchdining.domain.seat.model.SeatType;
+import com.jvnlee.catchdining.domain.seat.service.SeatService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static com.jvnlee.catchdining.domain.seat.model.SeatType.BAR;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = {SeatController.class},
+        excludeAutoConfiguration = SecurityAutoConfiguration.class
+)
+@MockBean(JpaMetamodelMappingContext.class)
+class SeatControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper om;
+
+    @MockBean
+    SeatService service;
+
+    @Test
+    @DisplayName("자리 등록 성공")
+    void add() throws Exception {
+        Authentication authentication = new UsernamePasswordAuthenticationToken("user", "password", AuthorityUtils.createAuthorityList("ROLE_OWNER"));
+
+        Long restaurantId = 1L;
+        List<LocalTime> timeList = List.of(LocalTime.of(12, 0), LocalTime.of(13, 0));
+        SeatDto seatDto = new SeatDto(BAR, timeList, 1, 2, 3);
+
+        String requestBody = om.writeValueAsString(seatDto);
+
+        ResultActions resultActions = mockMvc.perform(
+                post("/restaurants/{restaurantId}/seats", restaurantId)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authentication))
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        verify(service).add(restaurantId, seatDto);
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("자리 등록 성공"));
+    }
+
+    @Test
+    @DisplayName("예약 가능 시간 조회 성공")
+    void search_success() throws Exception {
+        Long restaurantId = 1L;
+        LocalDate date = LocalDate.of(2023, 3, 25);
+        SeatType seatType = BAR;
+        int headCount = 2;
+
+        List<SeatSearchDto> seatSearchDtoList = List.of(
+                new SeatSearchDto(1L, LocalTime.of(12, 0))
+        );
+
+        when(service.search(restaurantId, date, seatType, headCount)).thenReturn(seatSearchDtoList);
+
+        ResultActions resultActions = mockMvc.perform(
+                get("/restaurants/{restaurantId}/seats", restaurantId)
+                        .param("date", date.toString())
+                        .param("seatType", seatType.toString())
+                        .param("headCount", String.valueOf(headCount))
+        );
+
+        verify(service).search(restaurantId, date, seatType, headCount);
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("예약 가능 목록 조회 결과"))
+                .andExpect(jsonPath("$.data").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("예약 가능 시간 조회 실패: 결과 없음")
+    void search_fail() throws Exception {
+        Long restaurantId = 1L;
+        LocalDate date = LocalDate.of(2023, 3, 25);
+        SeatType seatType = BAR;
+        int headCount = 2;
+
+        when(service.search(restaurantId, date, seatType, headCount)).thenThrow(SeatNotFoundException.class);
+
+        ResultActions resultActions = mockMvc.perform(
+                get("/restaurants/{restaurantId}/seats", restaurantId)
+                        .param("date", date.toString())
+                        .param("seatType", seatType.toString())
+                        .param("headCount", String.valueOf(headCount))
+        );
+
+        verify(service).search(restaurantId, date, seatType, headCount);
+
+        resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("자리 정보가 존재하지 않습니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+}

--- a/src/test/java/com/jvnlee/catchdining/domain/seat/service/SeatServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/seat/service/SeatServiceTest.java
@@ -1,0 +1,87 @@
+package com.jvnlee.catchdining.domain.seat.service;
+
+import com.jvnlee.catchdining.common.exception.SeatNotFoundException;
+import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
+import com.jvnlee.catchdining.domain.restaurant.repository.RestaurantRepository;
+import com.jvnlee.catchdining.domain.seat.dto.SeatDto;
+import com.jvnlee.catchdining.domain.seat.dto.SeatSearchDto;
+import com.jvnlee.catchdining.domain.seat.model.Seat;
+import com.jvnlee.catchdining.domain.seat.repository.SeatRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.jvnlee.catchdining.domain.seat.model.SeatType.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SeatServiceTest {
+
+    @Mock
+    SeatRepository seatRepository;
+
+    @Mock
+    RestaurantRepository restaurantRepository;
+
+    @InjectMocks
+    SeatService seatService;
+
+    @Test
+    @DisplayName("자리 등록")
+    void add() {
+        Long restaurantId = 1L;
+        List<LocalTime> timeList = List.of(LocalTime.of(12, 0), LocalTime.of(13, 0));
+        SeatDto seatDto = new SeatDto(BAR, timeList, 1, 2, 3);
+
+        Restaurant restaurant = Restaurant.builder()
+                .name("r1")
+                .build();
+
+        when(restaurantRepository.findById(restaurantId))
+                .thenReturn(Optional.of(restaurant));
+
+        seatService.add(restaurantId, seatDto);
+
+        verify(seatRepository, times(14)).save(any(Seat.class));
+    }
+
+    @Test
+    @DisplayName("예약 가능 시간 조회 성공")
+    void search_success() {
+        LocalDate date = LocalDate.of(2023, 3, 25);
+        SeatSearchDto seatSearchDto = new SeatSearchDto();
+        when(seatRepository.findTimeByCond(1L, date, BAR, 2)).thenReturn(List.of(seatSearchDto));
+
+        List<SeatSearchDto> result = seatService.search(1L, date, BAR, 2);
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("예약 가능 시간 조회 실패: 결과 없음")
+    void search_fail() {
+        LocalDate date = LocalDate.of(2023, 3, 25);
+        when(seatRepository.findTimeByCond(1L, date, BAR, 2)).thenReturn(Collections.emptyList());
+
+        assertThatThrownBy(() -> seatService.search(1L, date, BAR, 2))
+                .isInstanceOf(SeatNotFoundException.class);
+    }
+
+    @Test
+    void updatePastDates() {
+        seatService.updatePastDates();
+        verify(seatRepository).updatePastDates(any(LocalDate.class), any(LocalDate.class));
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

### Repository

Spring Data JPA 방식의 SeatRepository 인터페이스를 추가함

- `findTimeByCond()`: `restaurantId`, `date`, `seatType`, `headCount`를 파라미터로 받아 조건에 부합하는 예약 가능 좌석의 시간 리스트를 반환

- `updatePastDates()`: `date`, `today`를 파라미터로 받아 `availableDate` 컬럼 값이  `today` 이전인 경우 값을 `date`로 변경하고, 해당 로우의 `availableQuantity`의 값도 `quantity`의 값으로 초기화

&nbsp;

### Service

SeatRepository를 의존성으로 갖는 SeatService 클래스를 추가함

- `add()`: 자리 신규 등록

    > 이 때 클라이언트는 날짜가 아닌 시간만 골라서 넘겨주면, 등록일 포함 RESERVABLE_DATE_LIMIT일치의 예약 가능 날짜 데이터를 포함해서 Seat을 생성 후 저장함.

- `search()`: 예약 가능한 자리의 시간 검색
- `updatePastDates()`: 매일 오전 3시에 자동 실행됨. 지나간 날짜를 가진 자리 데이터를 자체적으로 업데이트

    > `@Scheduled`를 사용해서 특정한 시간 주기로 자동 실행될 수 있게 설정함.

&nbsp;

### Controller

SeatService를 의존성으로 갖는 SeatController 클래스를 추가함

API 상세

| Method | Endpoint | Parameters | Authorities | Success | Fail |
| ----- | ----- | ----- | ----- | ----- | ----- |
| POST | /restaurants/{restaurantId}/seats | 없음 | OWNER | 200 | 400 |
| GET | /restaurants/{restaurantId}/seats | date, seatType, headCount | CUSTOMER, OWNER | 200 | 404 |

> `@PreAuthorize`로 Seat 등록에 대해서는 OWNER 권한이 있는 사용자만 접근할 수 있도록 제한

> Seat은 Restaurant에 종속적인 개념이기 때문에 API Endpoint를 restaurants 하위로 오게 설계함

&nbsp;

### 테스트 코드

- SeatServiceTest: SeatService의 메서드에 대한 단위 테스트 진행
- SeatControllerTest: SeatController의 메서드에 대한 단위 테스트 진행 (WebMvcTest)

&nbsp;

### 기타

Seat의 데이터를 수정하거나 삭제하는 기능을 구현하지 않음
> `updatePastDates()`는 클라이언트 요청에 의해 호출되는 것이 아닌 내부적으로 호출되는 메서드이므로 논외

Seat은 Reservation과 1대1 연관 관계를 가지고 있기 때문에, 특정 Seat에 대한 Reservation이 생성된 뒤에 Seat 데이터가 변경되면 Reservation 조회 시의 데이터에도 문제가 생길 수 있다고 판단함. 이 부분은 추후 Reservation API 구현 과정에서 적절한 해결책을 찾아야할 것으로 보임.