### PR TITLE
feature/#20 menu api crud

### DIFF
--- a/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
+++ b/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
@@ -3,6 +3,8 @@ package com.jvnlee.catchdining.common.advice;
 import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
 import com.jvnlee.catchdining.common.exception.UserNotFoundException;
 import com.jvnlee.catchdining.common.web.Response;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,6 +13,12 @@ import static org.springframework.http.HttpStatus.*;
 
 @RestControllerAdvice
 public class ControllerAdvice {
+
+    @ExceptionHandler(DuplicateKeyException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response handleDuplicateKey(DuplicateKeyException e) {
+        return new Response(e.getMessage());
+    }
 
     @ExceptionHandler(UserNotFoundException.class)
     @ResponseStatus(NOT_FOUND)

--- a/src/main/java/com/jvnlee/catchdining/common/exception/MenuNotFoundException.java
+++ b/src/main/java/com/jvnlee/catchdining/common/exception/MenuNotFoundException.java
@@ -1,0 +1,4 @@
+package com.jvnlee.catchdining.common.exception;
+
+public class MenuNotFoundException extends RuntimeException {
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/controller/MenuController.java
@@ -1,0 +1,47 @@
+package com.jvnlee.catchdining.domain.menu.controller;
+
+import com.jvnlee.catchdining.common.web.Response;
+import com.jvnlee.catchdining.domain.menu.dto.MenuDto;
+import com.jvnlee.catchdining.domain.menu.dto.MenuViewDto;
+import com.jvnlee.catchdining.domain.menu.service.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/restaurants/{restaurantId}/menus")
+@RequiredArgsConstructor
+public class MenuController {
+
+    private final MenuService menuService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ROLE_OWNER')")
+    public Response<Void> add(@PathVariable Long restaurantId, @RequestBody List<MenuDto> menuDtoList) {
+        menuService.add(restaurantId, menuDtoList);
+        return new Response<>("메뉴 등록 성공");
+    }
+
+    @GetMapping
+    public Response<List<MenuViewDto>> viewAll(@PathVariable Long restaurantId) {
+        List<MenuViewDto> data = menuService.viewAll(restaurantId);
+        return new Response<>("메뉴 조회 결과", data);
+    }
+
+    @PutMapping("/{menuId}")
+    @PreAuthorize("hasRole('ROLE_OWNER')")
+    public Response<Void> update(@PathVariable Long menuId, @RequestBody MenuDto menuDto) {
+        menuService.update(menuId, menuDto);
+        return new Response<>("메뉴 정보 업데이트 성공");
+    }
+
+    @DeleteMapping("/{menuId}")
+    @PreAuthorize("hasRole('ROLE_OWNER')")
+    public Response<Void> delete(@PathVariable Long menuId) {
+        menuService.delete(menuId);
+        return new Response<>("메뉴 삭제 성공");
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/domain/Menu.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/domain/Menu.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.domain.menu.domain;
 
+import com.jvnlee.catchdining.domain.menu.dto.MenuDto;
 import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
 import com.jvnlee.catchdining.entity.BaseEntity;
 import lombok.Getter;
@@ -29,4 +30,14 @@ public class Menu extends BaseEntity {
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 
+    public Menu(MenuDto menuDto, Restaurant restaurant) {
+        this.name = menuDto.getName();
+        this.price = menuDto.getPrice();
+        this.restaurant = restaurant;
+    }
+
+    public void update(MenuDto menuDto) {
+        this.name = menuDto.getName();
+        this.price = menuDto.getPrice();
+    }
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/domain/Menu.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/domain/Menu.java
@@ -1,6 +1,7 @@
-package com.jvnlee.catchdining.entity;
+package com.jvnlee.catchdining.domain.menu.domain;
 
 import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
+import com.jvnlee.catchdining.entity.BaseEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuDto.java
@@ -1,8 +1,10 @@
 package com.jvnlee.catchdining.domain.menu.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class MenuDto {
 
     private String name;

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuDto.java
@@ -1,0 +1,12 @@
+package com.jvnlee.catchdining.domain.menu.dto;
+
+import lombok.Data;
+
+@Data
+public class MenuDto {
+
+    private String name;
+
+    private int price;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuViewDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuViewDto.java
@@ -1,7 +1,11 @@
 package com.jvnlee.catchdining.domain.menu.dto;
 
 import com.jvnlee.catchdining.domain.menu.domain.Menu;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
+@Data
+@AllArgsConstructor
 public class MenuViewDto {
 
     private Long menuId;

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuViewDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuViewDto.java
@@ -1,0 +1,19 @@
+package com.jvnlee.catchdining.domain.menu.dto;
+
+import com.jvnlee.catchdining.domain.menu.domain.Menu;
+
+public class MenuViewDto {
+
+    private Long menuId;
+
+    private String name;
+
+    private int price;
+
+    public MenuViewDto(Menu menu) {
+        this.menuId = menu.getId();
+        this.name = menu.getName();
+        this.price = menu.getPrice();
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/repository/MenuRepository.java
@@ -2,6 +2,16 @@ package com.jvnlee.catchdining.domain.menu.repository;
 
 import com.jvnlee.catchdining.domain.menu.domain.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    Optional<Menu> findByName(String name);
+
+    @Query("select m from Menu m where m.restaurant.id = :restaurantId")
+    List<Menu> findAllByRestaurantId(Long restaurantId);
+
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/repository/MenuRepository.java
@@ -1,0 +1,7 @@
+package com.jvnlee.catchdining.domain.menu.repository;
+
+import com.jvnlee.catchdining.domain.menu.domain.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/service/MenuService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/service/MenuService.java
@@ -13,9 +13,10 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import static java.util.stream.Collectors.*;
 
 @Service
 @Transactional
@@ -40,11 +41,10 @@ public class MenuService {
     @Transactional(readOnly = true)
     public List<MenuViewDto> viewAll(Long restaurantId) {
         List<Menu> menuList = menuRepository.findAllByRestaurantId(restaurantId);
-        List<MenuViewDto> menuViewDtoList = new ArrayList<>();
-        for (Menu menu : menuList) {
-            menuViewDtoList.add(new MenuViewDto(menu));
-        }
-        return menuViewDtoList;
+        return menuList
+                .stream()
+                .map(MenuViewDto::new)
+                .collect(toList());
     }
 
     public void update(Long menuId, MenuDto menuDto) {

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/service/MenuService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/service/MenuService.java
@@ -1,0 +1,76 @@
+package com.jvnlee.catchdining.domain.menu.service;
+
+import com.jvnlee.catchdining.common.exception.MenuNotFoundException;
+import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
+import com.jvnlee.catchdining.domain.menu.domain.Menu;
+import com.jvnlee.catchdining.domain.menu.dto.MenuDto;
+import com.jvnlee.catchdining.domain.menu.dto.MenuViewDto;
+import com.jvnlee.catchdining.domain.menu.repository.MenuRepository;
+import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
+import com.jvnlee.catchdining.domain.restaurant.repository.RestaurantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MenuService {
+
+    private final MenuRepository menuRepository;
+
+    private final RestaurantRepository restaurantRepository;
+
+    public void add(Long restaurantId, List<MenuDto> menuDtoList) {
+        Restaurant restaurant = restaurantRepository
+                .findById(restaurantId)
+                .orElseThrow(RestaurantNotFoundException::new);
+        for (MenuDto menuDto : menuDtoList) {
+            validateName(menuDto.getName());
+            Menu menu = new Menu(menuDto, restaurant);
+            menuRepository.save(menu);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<MenuViewDto> viewAll(Long restaurantId) {
+        List<Menu> menuList = menuRepository.findAllByRestaurantId(restaurantId);
+        List<MenuViewDto> menuViewDtoList = new ArrayList<>();
+        for (Menu menu : menuList) {
+            menuViewDtoList.add(new MenuViewDto(menu));
+        }
+        return menuViewDtoList;
+    }
+
+    public void update(Long menuId, MenuDto menuDto) {
+        validateName(menuId, menuDto.getName());
+        Menu menu = menuRepository
+                .findById(menuId)
+                .orElseThrow(MenuNotFoundException::new);
+        menu.update(menuDto);
+    }
+
+    public void delete(Long menuId) {
+        menuRepository.deleteById(menuId);
+    }
+
+    private void validateName(String name) {
+        if (menuRepository.findByName(name).isPresent()) {
+            throw new DuplicateKeyException("이미 존재하는 메뉴명입니다.");
+        }
+    }
+
+    private void validateName(Long menuId, String name) {
+        Optional<Menu> menu = menuRepository.findByName(name);
+        if (menu.isPresent()) {
+            if (menu.get().getId().equals(menuId)) return;
+            throw new DuplicateKeyException("이미 존재하는 메뉴명입니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/controller/RestaurantController.java
@@ -1,19 +1,15 @@
 package com.jvnlee.catchdining.domain.restaurant.controller;
 
-import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
 import com.jvnlee.catchdining.common.web.Response;
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantDto;
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantSearchDto;
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantViewDto;
 import com.jvnlee.catchdining.domain.restaurant.service.RestaurantService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequestMapping("/restaurants")
@@ -53,12 +49,6 @@ public class RestaurantController {
     public Response<Void> delete(@PathVariable Long restaurantId) {
         restaurantService.delete(restaurantId);
         return new Response<>("식당 삭제 성공");
-    }
-
-    @ExceptionHandler(DuplicateKeyException.class)
-    @ResponseStatus(BAD_REQUEST)
-    public Response<Void> handleDuplicateName(DuplicateKeyException e) {
-        return new Response<>(e.getMessage());
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/model/Restaurant.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/model/Restaurant.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.domain.restaurant.model;
 
+import com.jvnlee.catchdining.domain.menu.domain.Menu;
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantDto;
 import com.jvnlee.catchdining.domain.seat.model.Seat;
 import com.jvnlee.catchdining.entity.*;

--- a/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/controller/UserController.java
@@ -5,8 +5,6 @@ import com.jvnlee.catchdining.domain.user.dto.UserDto;
 import com.jvnlee.catchdining.domain.user.dto.UserSearchDto;
 import com.jvnlee.catchdining.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DuplicateKeyException;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -38,12 +36,6 @@ public class UserController {
     public Response delete(@PathVariable Long userId) {
         userService.delete(userId);
         return new Response("회원 탈퇴 성공");
-    }
-
-    @ExceptionHandler(DuplicateKeyException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public Response handleDuplicateData(DuplicateKeyException e) {
-        return new Response(e.getMessage());
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/entity/ReserveMenu.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/ReserveMenu.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.entity;
 
+import com.jvnlee.catchdining.domain.menu.domain.Menu;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/test/java/com/jvnlee/catchdining/domain/menu/controller/MenuControllerTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/menu/controller/MenuControllerTest.java
@@ -1,0 +1,181 @@
+package com.jvnlee.catchdining.domain.menu.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jvnlee.catchdining.domain.menu.dto.MenuDto;
+import com.jvnlee.catchdining.domain.menu.dto.MenuViewDto;
+import com.jvnlee.catchdining.domain.menu.service.MenuService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static java.nio.charset.StandardCharsets.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        controllers = {MenuController.class},
+        excludeAutoConfiguration = SecurityAutoConfiguration.class
+)
+@WithMockUser(username = "user", roles = {"OWNER"})
+@MockBean(JpaMetamodelMappingContext.class)
+class MenuControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper om;
+
+    @MockBean
+    MenuService menuService;
+
+    @Test
+    @DisplayName("메뉴 등록 성공")
+    void add_success() throws Exception {
+        Long restaurantId = 1L;
+
+        List<MenuDto> menuDtoList = List.of(
+                new MenuDto("런치 오마카세", 80_000),
+                new MenuDto("디너 오마카세", 150_000)
+        );
+
+        String requestBody = om.writeValueAsString(menuDtoList);
+
+        ResultActions resultActions = mockMvc.perform(
+                post("/restaurants/{restaurantId}/menus", restaurantId)
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        verify(menuService).add(restaurantId, menuDtoList);
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("메뉴 등록 성공"));
+    }
+
+    @Test
+    @DisplayName("메뉴 등록 실패: 중복된 메뉴명")
+    void add_fail() throws Exception {
+        Long restaurantId = 1L;
+
+        List<MenuDto> menuDtoList = List.of(
+                new MenuDto("런치 오마카세", 80_000),
+                new MenuDto("디너 오마카세", 150_000)
+        );
+
+        String requestBody = om.writeValueAsString(menuDtoList);
+
+        doThrow(new DuplicateKeyException("이미 존재하는 메뉴명입니다.")).when(menuService).add(restaurantId, menuDtoList);
+
+        ResultActions resultActions = mockMvc.perform(
+                post("/restaurants/{restaurantId}/menus", restaurantId)
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        verify(menuService).add(restaurantId, menuDtoList);
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("이미 존재하는 메뉴명입니다."));
+    }
+
+    @Test
+    @DisplayName("메뉴 전체 조회 성공")
+    void viewAll() throws Exception {
+        Long restaurantId = 1L;
+
+        List<MenuViewDto> menuViewDtoList = List.of(
+                new MenuViewDto(1L, "런치 오마카세", 80_000)
+        );
+
+        when(menuService.viewAll(restaurantId)).thenReturn(menuViewDtoList);
+
+        ResultActions resultActions = mockMvc.perform(
+                get("/restaurants/{restaurantId}/menus", restaurantId)
+        );
+
+        verify(menuService).viewAll(restaurantId);
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("메뉴 조회 결과"))
+                .andExpect(jsonPath("$.data").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("메뉴 정보 업데이트 성공")
+    void update_success() throws Exception {
+        Long restaurantId = 1L;
+        Long menuId = 1L;
+
+        MenuDto updateMenuDto = new MenuDto("런치 오마카세", 80_000);
+
+        String requestBody = om.writeValueAsString(updateMenuDto);
+
+        ResultActions resultActions = mockMvc.perform(
+                put("/restaurants/{restaurantId}/menus/{menuId}", restaurantId, menuId)
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        verify(menuService).update(menuId, updateMenuDto);
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("메뉴 정보 업데이트 성공"));
+    }
+
+    @Test
+    @DisplayName("메뉴 정보 업데이트 실패")
+    void update_fail() throws Exception {
+        Long restaurantId = 1L;
+        Long menuId = 1L;
+
+        MenuDto updateMenuDto = new MenuDto("런치 오마카세", 80_000);
+
+        String requestBody = om.writeValueAsString(updateMenuDto);
+
+        doThrow(new DuplicateKeyException("이미 존재하는 메뉴명입니다.")).when(menuService).update(menuId, updateMenuDto);
+
+        ResultActions resultActions = mockMvc.perform(
+                put("/restaurants/{restaurantId}/menus/{menuId}", restaurantId, menuId)
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        verify(menuService).update(menuId, updateMenuDto);
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("이미 존재하는 메뉴명입니다."));
+    }
+
+    @Test
+    @DisplayName("메뉴 삭제 성공")
+    void delete_success() throws Exception {
+        Long restaurantId = 1L;
+        Long menuId = 1L;
+
+        ResultActions resultActions = mockMvc.perform(
+                delete("/restaurants/{restaurantId}/menus/{menuId}", restaurantId, menuId)
+        );
+
+        verify(menuService).delete(menuId);
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("메뉴 삭제 성공"));
+    }
+
+}

--- a/src/test/java/com/jvnlee/catchdining/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/menu/service/MenuServiceTest.java
@@ -1,0 +1,146 @@
+package com.jvnlee.catchdining.domain.menu.service;
+
+import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
+import com.jvnlee.catchdining.domain.menu.domain.Menu;
+import com.jvnlee.catchdining.domain.menu.dto.MenuDto;
+import com.jvnlee.catchdining.domain.menu.dto.MenuViewDto;
+import com.jvnlee.catchdining.domain.menu.repository.MenuRepository;
+import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
+import com.jvnlee.catchdining.domain.restaurant.repository.RestaurantRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MenuServiceTest {
+
+    @Mock
+    MenuRepository menuRepository;
+
+    @Mock
+    RestaurantRepository restaurantRepository;
+
+    @InjectMocks
+    MenuService menuService;
+
+    @Test
+    @DisplayName("메뉴 등록 성공")
+    void add_success() {
+        Long restaurantId = 1L;
+
+        List<MenuDto> menuDtoList = List.of(
+                new MenuDto("런치 오마카세", 80_000),
+                new MenuDto("디너 오마카세", 150_000)
+        );
+
+        Restaurant restaurant = mock(Restaurant.class);
+
+        when(restaurantRepository.findById(restaurantId)).thenReturn(Optional.of(restaurant));
+
+        menuService.add(restaurantId, menuDtoList);
+
+        verify(menuRepository, times(2)).save(any(Menu.class));
+    }
+
+    @Test
+    @DisplayName("메뉴 등록 실패: 존재하지 않는 식당")
+    void add_fail_no_restaurant() {
+        Long restaurantId = 1L;
+
+        List<MenuDto> menuDtoList = List.of(new MenuDto("런치 오마카세", 80_000));
+
+        when(restaurantRepository.findById(restaurantId)).thenThrow(RestaurantNotFoundException.class);
+
+        assertThatThrownBy(() -> menuService.add(restaurantId, menuDtoList))
+                .isInstanceOf(RestaurantNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("메뉴 등록 실패: 중복된 메뉴명")
+    void add_fail_duplicate_menu() {
+        Long restaurantId = 1L;
+
+        MenuDto menuDto = new MenuDto("런치 오마카세", 80_000);
+        List<MenuDto> menuDtoList = List.of(menuDto);
+
+        Restaurant restaurant = mock(Restaurant.class);
+
+        Menu menu = new Menu(menuDto, restaurant);
+
+        when(restaurantRepository.findById(restaurantId)).thenReturn(Optional.of(restaurant));
+        when(menuRepository.findByName("런치 오마카세")).thenReturn(Optional.of(menu));
+
+        assertThatThrownBy(() -> menuService.add(restaurantId, menuDtoList))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    @DisplayName("메뉴 전체 조회 성공")
+    void viewAll() {
+        Long restaurantId = 1L;
+
+        Menu menu1 = mock(Menu.class);
+        Menu menu2 = mock(Menu.class);
+
+        List<Menu> menuList = List.of(menu1, menu2);
+
+        when(menuRepository.findAllByRestaurantId(restaurantId)).thenReturn(menuList);
+
+        List<MenuViewDto> menuViewDtoList = menuService.viewAll(restaurantId);
+        assertThat(menuViewDtoList.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("메뉴 정보 업데이트 성공")
+    void update_success() {
+        Long menuId = 1L;
+        MenuDto menuDto = new MenuDto("런치 오마카세", 80_000);
+        MenuDto updateMenuDto = new MenuDto("디너 오마카세", 150_000);
+        Restaurant restaurant = mock(Restaurant.class);
+        Menu menu = new Menu(menuDto, restaurant);
+
+        when(menuRepository.findById(menuId)).thenReturn(Optional.of(menu));
+
+        menuService.update(menuId, updateMenuDto);
+
+        assertThat(menu.getName()).isEqualTo(updateMenuDto.getName());
+        assertThat(menu.getPrice()).isEqualTo(updateMenuDto.getPrice());
+    }
+
+    @Test
+    @DisplayName("메뉴 정보 업데이트 실패: 중복된 메뉴명")
+    void update_fail() {
+        Long menuId = 1L;
+        MenuDto updateMenuDto = new MenuDto("디너 오마카세", 300_000);
+        Menu menu = mock(Menu.class);
+
+        when(menuRepository.findByName(updateMenuDto.getName())).thenReturn(Optional.of(menu));
+        when(menu.getId()).thenReturn(2L);
+
+        assertThatThrownBy(() -> menuService.update(menuId, updateMenuDto))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    @DisplayName("메뉴 정보 삭제 성공")
+    void delete() {
+        Long menuId = 1L;
+
+        menuService.delete(menuId);
+
+        verify(menuRepository).deleteById(menuId);
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

### Repository

Spring Data JPA 방식의 MenuRepository 인터페이스를 추가함

- `findByName()`: 메뉴명을 파라미터로 받아 조건에 부합하는 메뉴 객체 반환

- `findAllByRestaurantId()`: 식당 id를 파라미터로 받아 해당 식당의 모든 메뉴를 리스트로 반환

&nbsp;

### Service

MenuRepository를 의존성으로 갖는 MenuService 클래스를 추가함

- `add()`: 메뉴 신규 등록

> `List` 타입으로 DTO 데이터를 받아오기 때문에 단건 및 복수건 등록이 가능함

- `viewAll()`: 특정 식당이 가진 모든 메뉴 조회

- `update()`: 특정 메뉴 정보 수정

- `delete()`: 특정 메뉴 정보 삭제

&nbsp;

### Controller

MenuService를 의존성으로 갖는 MenuController 클래스를 추가함

API 상세

| Method | Endpoint | Parameters | Authorities | Success | Fail |
| ----- | ----- | ----- | ----- | ----- | ----- |
| POST | /restaurants/{restaurantId}/menus | 없음 | OWNER | 200 | 400 |
| GET | /restaurants/{restaurantId}/menus | 없음 | CUSTOMER, OWNER | 200 | 404 |
| GET | /restaurants/{restaurantId}/menus/{menuId} | 없음 | OWNER | 200 | 400 |
| GET | /restaurants/{restaurantId}/menus/{menuId} | 없음 | OWNER | 200 | 400 |

> `@PreAuthorize`로 메뉴 등록, 수정, 삭제에 대해서는 OWNER 권한이 있는 사용자만 접근할 수 있도록 제한

> Menu는 Restaurant에 종속적인 개념이기 때문에 API Endpoint를 restaurants 하위로 오게 설계함

&nbsp;

### 테스트 코드

- MenuServiceTest: MenuService의 메서드에 대한 단위 테스트 진행

- MenuControllerTest: MenuController의 메서드에 대한 단위 테스트 진행 (WebMvcTest)