### PR TITLE
feature/#19 payment api create

### DIFF
--- a/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
+++ b/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
@@ -1,6 +1,8 @@
 package com.jvnlee.catchdining.common.advice;
 
+import com.jvnlee.catchdining.common.exception.NotEnoughSeatException;
 import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
+import com.jvnlee.catchdining.common.exception.SeatNotFoundException;
 import com.jvnlee.catchdining.common.exception.UserNotFoundException;
 import com.jvnlee.catchdining.common.web.Response;
 import org.springframework.dao.DuplicateKeyException;
@@ -16,20 +18,32 @@ public class ControllerAdvice {
 
     @ExceptionHandler(DuplicateKeyException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public Response handleDuplicateKey(DuplicateKeyException e) {
-        return new Response(e.getMessage());
+    public Response<Void> handleDuplicateKey(DuplicateKeyException e) {
+        return new Response<>(e.getMessage());
     }
 
     @ExceptionHandler(UserNotFoundException.class)
     @ResponseStatus(NOT_FOUND)
-    public Response handleUserNotFound() {
-        return new Response("존재하지 않는 사용자입니다.");
+    public Response<Void> handleUserNotFound() {
+        return new Response<>("존재하지 않는 사용자입니다.");
     }
 
     @ExceptionHandler(RestaurantNotFoundException.class)
     @ResponseStatus(NOT_FOUND)
     public Response<Void> handleRestaurantNotFound() {
         return new Response<>("식당 정보가 존재하지 않습니다.");
+    }
+
+    @ExceptionHandler(SeatNotFoundException.class)
+    @ResponseStatus(NOT_FOUND)
+    public Response<Void> handleSeatNotFound() {
+        return new Response<>("자리 정보가 존재하지 않습니다.");
+    }
+
+    @ExceptionHandler(NotEnoughSeatException.class)
+    @ResponseStatus(NOT_FOUND)
+    public Response<Void> handleNotEnoughSeat() {
+        return new Response<>("잔여 좌석이 존재하지 않습니다.");
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/common/exception/NotEnoughSeatException.java
+++ b/src/main/java/com/jvnlee/catchdining/common/exception/NotEnoughSeatException.java
@@ -1,0 +1,4 @@
+package com.jvnlee.catchdining.common.exception;
+
+public class NotEnoughSeatException extends RuntimeException {
+}

--- a/src/main/java/com/jvnlee/catchdining/common/exception/PaymentFailureException.java
+++ b/src/main/java/com/jvnlee/catchdining/common/exception/PaymentFailureException.java
@@ -1,0 +1,4 @@
+package com.jvnlee.catchdining.common.exception;
+
+public class PaymentFailureException extends RuntimeException {
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/controller/PaymentController.java
@@ -1,0 +1,28 @@
+package com.jvnlee.catchdining.domain.payment.controller;
+
+import com.jvnlee.catchdining.common.exception.PaymentFailureException;
+import com.jvnlee.catchdining.common.web.Response;
+import com.jvnlee.catchdining.domain.payment.dto.PaymentDto;
+import com.jvnlee.catchdining.domain.payment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping
+    public Response<Void> createPayment(@RequestBody PaymentDto paymentDto) {
+        paymentService.create(paymentDto);
+        return new Response<>("결제 성공");
+    }
+
+    @ExceptionHandler(PaymentFailureException.class)
+    public Response<Void> handlePaymentFailure() {
+        return new Response<>("결제 실패");
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/domain/Payment.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/domain/Payment.java
@@ -1,11 +1,16 @@
 package com.jvnlee.catchdining.domain.payment.domain;
 
 import com.jvnlee.catchdining.entity.BaseEntity;
+import com.jvnlee.catchdining.entity.ReserveMenu;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static javax.persistence.CascadeType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -21,13 +26,17 @@ public class Payment extends BaseEntity {
 
     private String tid;
 
+    @OneToMany(mappedBy = "payment", cascade = ALL)
+    private List<ReserveMenu> reserveMenus = new ArrayList<>();
+
     private int totalPrice;
 
     @Enumerated(EnumType.STRING)
     private PaymentType paymentType;
 
-    public Payment(String tid, int totalPrice, PaymentType paymentType) {
+    public Payment(String tid, List<ReserveMenu> reserveMenus, int totalPrice, PaymentType paymentType) {
         this.tid = tid;
+        this.reserveMenus = reserveMenus;
         this.totalPrice = totalPrice;
         this.paymentType = paymentType;
     }

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/domain/Payment.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/domain/Payment.java
@@ -1,5 +1,6 @@
-package com.jvnlee.catchdining.entity;
+package com.jvnlee.catchdining.domain.payment.domain;
 
+import com.jvnlee.catchdining.entity.BaseEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/domain/Payment.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/domain/Payment.java
@@ -6,9 +6,6 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -22,12 +19,17 @@ public class Payment extends BaseEntity {
     @Column(name = "payment_id")
     private Long id;
 
-    @OneToMany(mappedBy = "payment")
-    private List<ReserveMenu> reserveMenus = new ArrayList<>();
+    private String tid;
 
     private int totalPrice;
 
     @Enumerated(EnumType.STRING)
     private PaymentType paymentType;
+
+    public Payment(String tid, int totalPrice, PaymentType paymentType) {
+        this.tid = tid;
+        this.totalPrice = totalPrice;
+        this.paymentType = paymentType;
+    }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/domain/PaymentType.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/domain/PaymentType.java
@@ -1,4 +1,4 @@
-package com.jvnlee.catchdining.entity;
+package com.jvnlee.catchdining.domain.payment.domain;
 
 public enum PaymentType {
     CREDIT_CARD, NAVER_PAY, KAKAO_PAY

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/dto/PaymentDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/dto/PaymentDto.java
@@ -1,0 +1,19 @@
+package com.jvnlee.catchdining.domain.payment.dto;
+
+import com.jvnlee.catchdining.domain.payment.domain.PaymentType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PaymentDto {
+
+    private Long seatId;
+
+    private List<ReserveMenuDto> reserveMenus;
+
+    private PaymentType paymentType;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/dto/ReserveMenuDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/dto/ReserveMenuDto.java
@@ -1,0 +1,16 @@
+package com.jvnlee.catchdining.domain.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ReserveMenuDto {
+
+    private Long menuId;
+
+    private int reservePrice;
+
+    private int quantity;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.jvnlee.catchdining.domain.payment.repository;
+
+import com.jvnlee.catchdining.domain.payment.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/service/FakePaymentModule.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/service/FakePaymentModule.java
@@ -1,0 +1,14 @@
+package com.jvnlee.catchdining.domain.payment.service;
+
+import static java.util.UUID.randomUUID;
+
+// 가상의 외부 결제 모듈
+public class FakePaymentModule {
+
+    public String attemptPayment(int totalPrice) {
+        // 결제 성공 시, UUID 문자열을 반환하고 결제 실패 시 빈 문자열을 반환하는 것으로 함
+        // 결제 실패 조건: totalPrice가 10,000원인 경우
+        return totalPrice == 10_000 ? "" : randomUUID().toString();
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/service/FakePaymentModule.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/service/FakePaymentModule.java
@@ -1,8 +1,11 @@
 package com.jvnlee.catchdining.domain.payment.service;
 
+import org.springframework.stereotype.Component;
+
 import static java.util.UUID.randomUUID;
 
 // 가상의 외부 결제 모듈
+@Component
 public class FakePaymentModule {
 
     public String attemptPayment(int totalPrice) {

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/service/PaymentService.java
@@ -33,6 +33,7 @@ public class PaymentService {
 
     private final FakePaymentModule fakePaymentModule;
 
+    @Transactional(timeout = 300)
     public void create(PaymentDto paymentDto) {
         Seat seat = seatRepository
                 .findWithLockById(paymentDto.getSeatId())

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/service/PaymentService.java
@@ -36,7 +36,7 @@ public class PaymentService {
         PaymentType paymentType = paymentDto.getPaymentType();
         int total = paymentDto.getReserveMenus()
                 .stream()
-                .mapToInt(ReserveMenuDto::getReservePrice)
+                .mapToInt(r -> r.getReservePrice() * r.getQuantity())
                 .sum();
 
         // 외부 결제 API 호출 (가상으로 하기 위해 FakePaymentModule 활용)

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/service/PaymentService.java
@@ -1,0 +1,54 @@
+package com.jvnlee.catchdining.domain.payment.service;
+
+import com.jvnlee.catchdining.common.exception.NotEnoughSeatException;
+import com.jvnlee.catchdining.common.exception.PaymentFailureException;
+import com.jvnlee.catchdining.common.exception.SeatNotFoundException;
+import com.jvnlee.catchdining.domain.payment.domain.Payment;
+import com.jvnlee.catchdining.domain.payment.domain.PaymentType;
+import com.jvnlee.catchdining.domain.payment.dto.PaymentDto;
+import com.jvnlee.catchdining.domain.payment.dto.ReserveMenuDto;
+import com.jvnlee.catchdining.domain.payment.repository.PaymentRepository;
+import com.jvnlee.catchdining.domain.seat.model.Seat;
+import com.jvnlee.catchdining.domain.seat.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    private final SeatRepository seatRepository;
+
+    private final FakePaymentModule fakePaymentModule;
+
+    public void create(PaymentDto paymentDto) {
+        Seat seat = seatRepository.findById(paymentDto.getSeatId()).orElseThrow(SeatNotFoundException::new);
+        if (seat.getAvailableQuantity() > 0) {
+            seat.occupy();
+        } else {
+            throw new NotEnoughSeatException();
+        }
+
+        PaymentType paymentType = paymentDto.getPaymentType();
+        int total = paymentDto.getReserveMenus()
+                .stream()
+                .mapToInt(ReserveMenuDto::getReservePrice)
+                .sum();
+
+        // 외부 결제 API 호출 (가상으로 하기 위해 FakePaymentModule 활용)
+        // tid: 결제 성공 시 받아오는 결제 고유 번호 문자열
+        String tid = fakePaymentModule.attemptPayment(total);
+        if (tid.isEmpty()) {
+            throw new PaymentFailureException();
+        }
+
+        Payment payment = new Payment(tid, total, paymentType);
+
+        paymentRepository.save(payment);
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/model/Seat.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/model/Seat.java
@@ -47,4 +47,8 @@ public class Seat extends BaseEntity {
 
     private int availableQuantity;
 
+    public void occupy() {
+        this.availableQuantity--;
+    }
+
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/repository/SeatRepository.java
@@ -4,11 +4,15 @@ import com.jvnlee.catchdining.domain.seat.dto.SeatSearchDto;
 import com.jvnlee.catchdining.domain.seat.model.Seat;
 import com.jvnlee.catchdining.domain.seat.model.SeatType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+
+import static javax.persistence.LockModeType.*;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
@@ -26,5 +30,8 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
             "s.availableQuantity = s.quantity " +
             "where s.availableDate < :today")
     void updatePastDates(LocalDate date, LocalDate today);
+
+    @Lock(PESSIMISTIC_WRITE)
+    Optional<Seat> findWithLockById(Long id);
 
 }

--- a/src/main/java/com/jvnlee/catchdining/entity/Reservation.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/Reservation.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.entity;
 
+import com.jvnlee.catchdining.domain.payment.domain.Payment;
 import com.jvnlee.catchdining.domain.seat.model.Seat;
 import com.jvnlee.catchdining.domain.user.model.User;
 import lombok.Getter;

--- a/src/main/java/com/jvnlee/catchdining/entity/ReserveMenu.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/ReserveMenu.java
@@ -1,6 +1,7 @@
 package com.jvnlee.catchdining.entity;
 
 import com.jvnlee.catchdining.domain.menu.domain.Menu;
+import com.jvnlee.catchdining.domain.payment.domain.Payment;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,5 +32,11 @@ public class ReserveMenu extends BaseEntity {
     private int reservePrice;
 
     private int quantity;
+
+    public ReserveMenu(Menu menu, int reservePrice, int quantity) {
+        this.menu = menu;
+        this.reservePrice = reservePrice;
+        this.quantity = quantity;
+    }
 
 }

--- a/src/test/java/com/jvnlee/catchdining/integration/PaymentIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/PaymentIntegrationTest.java
@@ -1,0 +1,85 @@
+package com.jvnlee.catchdining.integration;
+
+import com.jvnlee.catchdining.domain.menu.dto.MenuDto;
+import com.jvnlee.catchdining.domain.menu.service.MenuService;
+import com.jvnlee.catchdining.domain.payment.domain.PaymentType;
+import com.jvnlee.catchdining.domain.payment.dto.PaymentDto;
+import com.jvnlee.catchdining.domain.payment.dto.ReserveMenuDto;
+import com.jvnlee.catchdining.domain.payment.service.PaymentService;
+import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantDto;
+import com.jvnlee.catchdining.domain.restaurant.service.RestaurantService;
+import com.jvnlee.catchdining.domain.seat.dto.SeatDto;
+import com.jvnlee.catchdining.domain.seat.model.Seat;
+import com.jvnlee.catchdining.domain.seat.model.SeatType;
+import com.jvnlee.catchdining.domain.seat.repository.SeatRepository;
+import com.jvnlee.catchdining.domain.seat.service.SeatService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PaymentIntegrationTest {
+
+    @Autowired
+    RestaurantService restaurantService;
+
+    @Autowired
+    SeatService seatService;
+
+    @Autowired
+    MenuService menuService;
+
+    @Autowired
+    PaymentService paymentService;
+
+    @Autowired
+    SeatRepository seatRepository;
+
+    @Test
+    @DisplayName("100개의 결제 요청으로 예약 동시성 테스트")
+    void create() throws InterruptedException {
+        restaurantService.register(RestaurantDto.builder().name("r1").build());
+
+        seatService.add(1L, new SeatDto(
+                SeatType.BAR,
+                List.of(LocalTime.of(13, 0, 0)),
+                1,
+                2,
+                100
+        ));
+
+        menuService.add(1L, List.of(new MenuDto("sushi", 10000)));
+
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    paymentService.create(new PaymentDto(
+                            1L,
+                            List.of(new ReserveMenuDto(1L, 8000, 1)),
+                            PaymentType.CREDIT_CARD
+                    ));
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Seat seat = seatRepository.findById(1L).orElseThrow();
+        assertThat(seat.getAvailableQuantity()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 구현 내용

### Repository

Spring Data JPA 방식의 PaymentRepository 인터페이스를 추가함

&nbsp;

### Service

PaymentRepository를 의존성으로 갖는 PaymentService 클래스를 추가함

- `create()`: 결제 데이터 생성

> 고객의 결제 요청이 들어오면 예약 가능 여부를 확인한 뒤, 내부적으로 결제 모듈(`FakePaymentModule`)에 결제 요청을 보냄
>
> 결제에 성공하면 결제 데이터를 생성해서 저장함.

&nbsp;

### Controller

PaymentService를 의존성으로 갖는 PaymentController 클래스를 추가함

API 상세

| Method | Endpoint | Parameters | Authorities | Success | Fail |
| ----- | ----- | ----- | ----- | ----- | ----- |
| POST | /payments | 없음 | CUSTOMER | 200 | 400 |

&nbsp;

### 테스트 코드

- PaymentIntegerationTest: PaymentService에 대한 통합 테스트

> 동시에 다수의 예약 요청이 들어왔을 때, 순차적으로 처리하여 초과 예약이나 전체 요청 실패 같은 문제가 발생하지 않는지 테스트함