### PR TITLE
feature/#26 docker application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM openjdk:11-jdk
+
+ARG JAR_FILE=build/libs/*.jar
+
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "/app.jar"]
+

--- a/build.gradle
+++ b/build.gradle
@@ -41,3 +41,7 @@ tasks.named('test') {
 jar {
 	enabled = false
 }
+
+bootJar {
+	archiveFileName = 'app.jar'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -37,3 +37,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+jar {
+	enabled = false
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3"
+
+services:
+  app:
+    container_name: catch_dining_app
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+      - cache
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/catch_dining
+      - SPRING_DATASOURCE_USERNAME=root
+      - SPRING_DATASOURCE_PASSWORD=1234
+
+  db:
+    container_name: mysql
+    image: mysql:8.0.32
+    ports:
+      - "3306:3306"
+    restart: always
+    volumes:
+      - ./db:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_HOST=%
+      - MYSQL_ROOT_PASSWORD=1234
+      - MYSQL_DATABASE=catch_dining
+
+  cache:
+    container_name: redis
+    image: redis:7.0.14
+    ports:
+      - "6379:6379"
+    restart: always

--- a/src/test/java/com/jvnlee/catchdining/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/user/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -25,6 +26,9 @@ class UserServiceTest {
 
     @Mock
     UserRepository userRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
 
     @InjectMocks
     UserService userService;

--- a/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
@@ -78,7 +78,7 @@ class LoginIntegrationTest {
 
         resultActions
                 .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isNotFound());
     }
 
     @Test


### PR DESCRIPTION
## 구현 내용

### Dockerfile

해당 Spring Boot 애플리케이션의 고유 이미지를 생성하기 위한 파일

build.gradle 옵션 변경

Spring Boot 2.5 이상부터는 Gradle 빌드 시 Jar 파일이 2개 생성되기 때문에 (project name-ver.jar 와 project name-ver-plain.jar) build.gradle에 jar enabled 옵션을 false로 지정함. 그리고 bootJar 태스크로 생성되는 Jar 파일의 이름이 app.jar가 되도록 설정함.

> plain jar 파일은 일반 jar과는 다르게 애플리케이션 실행에 필요한 모든 의존성을 포함하지 않음.
>
> 이 파일을 Dockerfile ENTRYPOINT에 명시된 `java -jar` 명령어로 실행하면 에러 발생 가능
>
> 따라서 혹시 모를 충돌을 방지하기 위해 애초에 plain jar 파일이 생성되지 않도록 함

&nbsp;

### docker-compose.yml

애플리케이션과 함께 실행되어야하는 MySQL 및 Redis 컨테이너를 하나로 묶어서 관리하기 위한 파일
> docker compose가 없다면 모든 컨테이너를 개별적으로 올려야 함

데이터베이스인 MySQL의 경우, 컨테이너가 재시작할 때마다 데이터가 모두 날아가면 안되기 때문에 volume을 별도로 설정해서 데이터를 보관하고 동기화할 수 있도록 함.

명시된 환경변수들은 외부에 노출되면 보안상 좋지 않기 때문에 추후 처리할 예정.