### PR TITLE
feature/#26 docker application: fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,15 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - db
-      - cache
+      - mysql
+      - redis
     environment:
-      - SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/catch_dining
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/catch_dining
       - SPRING_DATASOURCE_USERNAME=root
       - SPRING_DATASOURCE_PASSWORD=1234
+      - SPRING_REDIS_HOST=redis
 
-  db:
+  mysql:
     container_name: mysql
     image: mysql:8.0.32
     ports:
@@ -29,7 +30,7 @@ services:
       - MYSQL_ROOT_PASSWORD=1234
       - MYSQL_DATABASE=catch_dining
 
-  cache:
+  redis:
     container_name: redis
     image: redis:7.0.14
     ports:


### PR DESCRIPTION
### 문제

#27 에서 생성한 docker-compose.yml 로 로컬 환경에서 컨테이너를 올리고 테스트 해보던 중에 Redis 연결이 되지 않는 문제가 발생함.

&nbsp;

### 원인

Redis의 호스트명이 localhost로 되어있음

> application-redis.properties 파일에 `spring.redis.host=localhost`로 명시해둔 상태였음

&nbsp;

### 해결 방법

Docker 없이 로컬에서 직접 애플리케이션 서버와 Redis 서버를 올려 테스트할 때는 로컬 PC 안에서 모든 것을 올려서 사용하므로 Redis의 호스트명이 localhost여도 정상 작동했음. 그러나 Docker 컨테이너 환경에서는 localhost가 각 컨테이너 자신을 가리키므로, 애플리케이션 컨테이너에서 Redis 컨테이너로 커넥션을 만드려면 docker-compose.yml에 명시된 서비스명인 `redis`로 호스트명을 변경해야함.

app 서비스의 환경변수에 REDIS_HOST 항목을 추가하고 호스트명을 redis로 지정함.

> docker-compose.yml에 명시한 환경변수들은 application.properties에 명시한 것들보다 우선하므로, properties 파일은 변경할 필요 없음.

&nbsp;

### 변경 사항

직관적인 사용을 위해 yml에 명시된 DB 서비스명을 각각 mysql과 redis로 변경함.