### PR TITLE
refactor/#34 notification failure handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'com.google.firebase:firebase-admin:9.2.0'
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework:spring-aspects'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
 			'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/jvnlee/catchdining/CatchdiningApplication.java
+++ b/src/main/java/com/jvnlee/catchdining/CatchdiningApplication.java
@@ -3,6 +3,7 @@ package com.jvnlee.catchdining;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -10,6 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaAuditing
 @EnableScheduling
 @EnableAsync
+@EnableRetry
 public class CatchdiningApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/jvnlee/catchdining/common/exception/MessageSendingFailureException.java
+++ b/src/main/java/com/jvnlee/catchdining/common/exception/MessageSendingFailureException.java
@@ -1,0 +1,4 @@
+package com.jvnlee.catchdining.common.exception;
+
+public class MessageSendingFailureException extends RuntimeException {
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/notification/service/FirebaseMessagingService.java
@@ -18,7 +18,6 @@ public class FirebaseMessagingService {
     @Retryable(
             value = MessageSendingFailureException.class,
             backoff = @Backoff(delay = 500L)
-            // maxAttempts = 3 (default)
     )
     public void send(Message message) throws MessageSendingFailureException {
         try {

--- a/src/main/java/com/jvnlee/catchdining/domain/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/notification/service/FirebaseMessagingService.java
@@ -1,0 +1,28 @@
+package com.jvnlee.catchdining.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import lombok.RequiredArgsConstructor;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FirebaseMessagingService {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    @Transactional
+    @Retryable(
+            value = FirebaseMessagingException.class,
+            backoff = @Backoff(delay = 500L)
+            // maxAttempts = 3 (default)
+    )
+    public void send(Message message) throws FirebaseMessagingException {
+        firebaseMessaging.send(message);
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/notification/service/FirebaseMessagingService.java
@@ -3,6 +3,7 @@ package com.jvnlee.catchdining.domain.notification.service;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.jvnlee.catchdining.common.exception.MessageSendingFailureException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -17,12 +18,16 @@ public class FirebaseMessagingService {
 
     @Transactional
     @Retryable(
-            value = FirebaseMessagingException.class,
+            value = MessageSendingFailureException.class,
             backoff = @Backoff(delay = 500L)
             // maxAttempts = 3 (default)
     )
-    public void send(Message message) throws FirebaseMessagingException {
-        firebaseMessaging.send(message);
+    public void send(Message message) throws MessageSendingFailureException {
+        try {
+            firebaseMessaging.send(message);
+        } catch (FirebaseMessagingException e) {
+            throw new MessageSendingFailureException();
+        }
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/notification/service/FirebaseMessagingService.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,7 +15,6 @@ public class FirebaseMessagingService {
 
     private final FirebaseMessaging firebaseMessaging;
 
-    @Transactional
     @Retryable(
             value = MessageSendingFailureException.class,
             backoff = @Backoff(delay = 500L)

--- a/src/main/java/com/jvnlee/catchdining/domain/notification/service/NotificationRequestService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/notification/service/NotificationRequestService.java
@@ -1,6 +1,5 @@
 package com.jvnlee.catchdining.domain.notification.service;
 
-import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
@@ -41,7 +40,7 @@ public class NotificationRequestService {
 
     private final NotificationRequestRepository notificationRequestRepository;
 
-    private final FirebaseMessaging firebaseMessaging;
+    private final FirebaseMessagingService firebaseMessagingService;
 
     public void request(Long restaurantId, NotificationRequestDto notificationRequestDto) {
         String fcmToken = notificationRequestDto.getFcmToken();
@@ -84,7 +83,7 @@ public class NotificationRequestService {
                         .build();
 
                 try {
-                    firebaseMessaging.send(message);
+                    firebaseMessagingService.send(message);
                 } catch (FirebaseMessagingException e) {
                     log.error(e.getErrorCode().toString() + ": " + e.getMessage());
                 }

--- a/src/main/java/com/jvnlee/catchdining/domain/notification/service/NotificationRequestService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/notification/service/NotificationRequestService.java
@@ -61,7 +61,7 @@ public class NotificationRequestService {
 
     @Async
     public void notify(Long restaurantId, LocalDate date, DiningPeriod diningPeriod, int minHeadCount, int maxHeadCount) {
-        List<NotificationRequest> list = notificationRequestRepository
+        List<NotificationRequest> notificationRequests = notificationRequestRepository
                 .findAllByCond(
                         restaurantId,
                         date,
@@ -70,24 +70,24 @@ public class NotificationRequestService {
                         maxHeadCount
                 );
 
-        if (list.isEmpty()) return;
+        if (notificationRequests.isEmpty()) return;
 
-        List<Long> userIdList = list
+        List<Long> userIds = notificationRequests
                 .stream()
                 .map(nr -> nr.getUser().getId())
                 .collect(toList());
 
-        List<String> fcmTokens = userService.getFcmTokens(userIdList);
+        List<String> fcmTokens = userService.getFcmTokens(userIds);
+
+        Notification notification = Notification.builder()
+                .setTitle("빈 자리 알림")
+                .setBody("신청하신 시간대에 빈 자리가 생겼습니다. 지금 예약해보세요!")
+                .build();
 
         for (String fcmToken : fcmTokens) {
             if (fcmToken == null) {
                 throw new FcmTokenNotFoundException();
             }
-
-            Notification notification = Notification.builder()
-                    .setTitle("빈 자리 알림")
-                    .setBody("신청하신 시간대에 빈 자리가 생겼습니다. 지금 예약해보세요!")
-                    .build();
 
             Message message = Message.builder()
                     .setToken(fcmToken)

--- a/src/main/java/com/jvnlee/catchdining/domain/notification/service/NotificationRequestService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/notification/service/NotificationRequestService.java
@@ -1,20 +1,20 @@
 package com.jvnlee.catchdining.domain.notification.service;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import com.jvnlee.catchdining.common.exception.DuplicateNotificationRequestException;
 import com.jvnlee.catchdining.common.exception.FcmTokenNotFoundException;
+import com.jvnlee.catchdining.common.exception.MessageSendingFailureException;
 import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
 import com.jvnlee.catchdining.domain.notification.dto.NotificationRequestDto;
 import com.jvnlee.catchdining.domain.notification.dto.NotificationRequestViewDto;
+import com.jvnlee.catchdining.domain.notification.model.DiningPeriod;
 import com.jvnlee.catchdining.domain.notification.model.NotificationRequest;
 import com.jvnlee.catchdining.domain.notification.repository.NotificationRequestRepository;
 import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
 import com.jvnlee.catchdining.domain.restaurant.repository.RestaurantRepository;
 import com.jvnlee.catchdining.domain.user.model.User;
 import com.jvnlee.catchdining.domain.user.service.UserService;
-import com.jvnlee.catchdining.domain.notification.model.DiningPeriod;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -96,8 +96,8 @@ public class NotificationRequestService {
 
             try {
                 firebaseMessagingService.send(message);
-            } catch (FirebaseMessagingException e) {
-                log.error(e.getErrorCode().toString() + ": " + e.getMessage());
+            } catch (MessageSendingFailureException e) {
+                log.error(e.getMessage());
             }
         }
     }

--- a/src/test/java/com/jvnlee/catchdining/domain/notification/service/FirebaseMessagingServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/notification/service/FirebaseMessagingServiceTest.java
@@ -1,0 +1,40 @@
+package com.jvnlee.catchdining.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.jvnlee.catchdining.common.exception.MessageSendingFailureException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.retry.annotation.EnableRetry;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@EnableRetry
+public class FirebaseMessagingServiceTest {
+
+    @MockBean
+    FirebaseMessaging firebaseMessaging;
+
+    @Autowired
+    FirebaseMessagingService firebaseMessagingService;
+
+    @Test
+    @DisplayName("FCM에 알림 전송 요청 실패 후 재시도 (3회)")
+    void send_fail_retry() throws FirebaseMessagingException {
+        when(firebaseMessaging.send(any(Message.class)))
+                .thenThrow(FirebaseMessagingException.class);
+
+        assertThatThrownBy(() -> firebaseMessagingService.send(mock(Message.class)))
+                .isInstanceOf(MessageSendingFailureException.class);
+
+        verify(firebaseMessaging, times(3)).send(any(Message.class));
+    }
+
+}

--- a/src/test/java/com/jvnlee/catchdining/domain/notification/service/NotificationRequestServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/notification/service/NotificationRequestServiceTest.java
@@ -1,7 +1,5 @@
 package com.jvnlee.catchdining.domain.notification.service;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.jvnlee.catchdining.common.exception.DuplicateNotificationRequestException;
 import com.jvnlee.catchdining.common.exception.FcmTokenNotFoundException;
@@ -27,9 +25,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.jvnlee.catchdining.domain.notification.model.DiningPeriod.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.jvnlee.catchdining.domain.notification.model.DiningPeriod.LUNCH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,7 +43,7 @@ class NotificationRequestServiceTest {
     NotificationRequestRepository notificationRequestRepository;
 
     @Mock
-    FirebaseMessaging firebaseMessaging;
+    FirebaseMessagingService firebaseMessagingService;
 
     @InjectMocks
     NotificationRequestService notificationRequestService;
@@ -102,7 +100,7 @@ class NotificationRequestServiceTest {
 
     @Test
     @DisplayName("알림 발행 성공")
-    void notify_success() throws FirebaseMessagingException {
+    void notify_success() {
         Long restaurantId = 1L;
         LocalDate date = LocalDate.of(2023, 1, 1);
 
@@ -112,7 +110,7 @@ class NotificationRequestServiceTest {
 
         notificationRequestService.notify(restaurantId, date, LUNCH, 1, 2);
 
-        verify(firebaseMessaging).send(any(Message.class));
+        verify(firebaseMessagingService).send(any(Message.class));
     }
 
     @Test


### PR DESCRIPTION
## 구현 내용

예외 발생으로 인해 FCM 알림 발송 요청에 실패하는 경우, 요청을 재시도하는 로직 추가

Spring Retry 라이브러리 사용 

[Spring Retry에 대해 정리한 글](https://jvnlee.vercel.app/spring-retry)

&nbsp;

## FirebaseMessagingService

- `send()`: 실제 알림 발송 요청을 하는 `FirebaseMessaging`의 `send()`를 호출하는 역할.

  - Spring Retry 라이브러리의 `@Retryable`을 사용해서 `MessageSendingFailureException` 발생 시 재시도를 수행함.
  
    > Spring AOP를 통해 동작하기 때문에 복잡한 구현 없이도 어노테이션 하나로 재시도 명령을 할 수 있음
  
  - `FirebaseMessagingException` 발생 시,  `MessageSendingFailureException`으로 전환해서 되던짐.
  
    >   호출부인 `NotificationRequestService`의 `notify()`가 구체적인 예외에 의존하지 않게 하기 위함
    >
    >   만약 추후 FCM 대신 다른 알림 발송 모듈을 사용하게 되더라도 코드 변경점을 최소화 할 수 있음

&nbsp;

## 해결하지 못한 부분

지정된 횟수의 재시도를 하고나서도 실패한다면 더 이상의 처리가 불가능함

&nbsp;

## etc

해당 브랜치의 작업은 "재시도 기능 추가"이기 때문에 이에 맞게 `feature` 태그로 변경했으나, `refactor`로 되어있는 기존 브랜치 이름은 이미 PR이 올라와있어 정상적으로 변경이 불가능했음.