### PR TITLE
refactor/#37 test environment improvement

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,21 +21,6 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      - name: Set up MySQL
-        uses: mirromutth/mysql-action@v1.1
-        with:
-          mysql version: '8.0.32'
-          mysql database: 'catch_dining'
-          mysql root password: ${{ secrets.DB_PASSWORD }}
-          mysql user: ${{ secrets.DB_USERNAME }}
-          mysql password: ${{ secrets.DB_PASSWORD }}
-
-      - name: Set up Redis
-        uses: zhulik/redis-action@1.1.0
-        with:
-          redis version: '7.0.14'
-          number of databases: 1
-
       - name: Create application-prod.yml
         run: |
           cd ./src/main/resources

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,13 +36,10 @@ jobs:
           redis version: '7.0.14'
           number of databases: 1
 
-      - name: Complete properties files
+      - name: Create application-prod.yml
         run: |
           cd ./src/main/resources
-          echo "${{ secrets.APP_CONFIG }}" >> ./application.properties
-          
-          cd ../../../src/test/resources
-          echo "${{ secrets.TEST_CONFIG }}" >> ./application.properties
+          echo "${{ secrets.PROD_CONFIG }}" >> ./application-prod.yml
 
       - name: Add database schema
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ ARG JAR_FILE=build/libs/*.jar
 
 COPY ${JAR_FILE} app.jar
 
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar", "-Dspring.profiles.active=prod"]
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	testImplementation 'org.testcontainers:testcontainers:1.19.8'
 	testImplementation 'org.testcontainers:mysql:1.19.8'
 	testImplementation 'com.redis:testcontainers-redis:2.2.2'
+	testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.testcontainers:testcontainers:1.19.8'
+	testImplementation 'org.testcontainers:mysql:1.19.8'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.testcontainers:testcontainers:1.19.8'
 	testImplementation 'org.testcontainers:mysql:1.19.8'
-	testImplementation 'com.redis:testcontainers-redis:2.2.2'
 	testImplementation ('io.rest-assured:rest-assured:5.4.0') {
 		exclude group: 'org.apache.groovy', module: 'groovy'
 		exclude group: 'org.apache.groovy', module: 'groovy-xml'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.testcontainers:testcontainers:1.19.8'
 	testImplementation 'org.testcontainers:mysql:1.19.8'
+	testImplementation 'com.redis:testcontainers-redis:2.2.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,10 @@ dependencies {
 	testImplementation 'org.testcontainers:testcontainers:1.19.8'
 	testImplementation 'org.testcontainers:mysql:1.19.8'
 	testImplementation 'com.redis:testcontainers-redis:2.2.2'
-	testImplementation 'io.rest-assured:rest-assured:5.4.0'
+	testImplementation ('io.rest-assured:rest-assured:5.4.0') {
+		exclude group: 'org.apache.groovy', module: 'groovy'
+		exclude group: 'org.apache.groovy', module: 'groovy-xml'
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
+++ b/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
@@ -20,7 +20,7 @@ public class ControllerAdvice {
     }
 
     @ExceptionHandler(UserNotFoundException.class)
-    @ResponseStatus(NOT_FOUND)
+    @ResponseStatus(BAD_REQUEST)
     public Response<Void> handleUserNotFound() {
         return new Response<>("존재하지 않는 사용자입니다.");
     }

--- a/src/main/java/com/jvnlee/catchdining/common/config/SecurityConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/SecurityConfig.java
@@ -9,13 +9,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import static org.springframework.http.HttpStatus.*;
 import static org.springframework.security.config.http.SessionCreationPolicy.*;
 
 @Configuration
@@ -42,6 +45,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests()
                 .antMatchers("/users", "/login").permitAll() // 회원가입(POST /users), 로그인(POST /login) URL 접근 허용
                 .anyRequest().authenticated() // 그 외에는 모두 로그인 후 접근 허용
+                .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(new HttpStatusEntryPoint(UNAUTHORIZED))
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtService, userRepository, redisTemplate),
                         UsernamePasswordAuthenticationFilter.class) // 모든 AuthentiationFilter 중에 가장 앞에 배치

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuDto.java
@@ -2,8 +2,11 @@ package com.jvnlee.catchdining.domain.menu.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.checkerframework.checker.units.qual.N;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class MenuDto {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuViewDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/menu/dto/MenuViewDto.java
@@ -3,8 +3,10 @@ package com.jvnlee.catchdining.domain.menu.dto;
 import com.jvnlee.catchdining.domain.menu.domain.Menu;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class MenuViewDto {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/dto/PaymentDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/dto/PaymentDto.java
@@ -3,10 +3,13 @@ package com.jvnlee.catchdining.domain.payment.dto;
 import com.jvnlee.catchdining.domain.payment.model.PaymentType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.checkerframework.checker.units.qual.N;
 
 import java.util.List;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class PaymentDto {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/payment/dto/ReserveMenuDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/payment/dto/ReserveMenuDto.java
@@ -2,8 +2,10 @@ package com.jvnlee.catchdining.domain.payment.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class ReserveMenuDto {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/reservation/dto/ReservationDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/reservation/dto/ReservationDto.java
@@ -4,10 +4,12 @@ import com.jvnlee.catchdining.domain.payment.model.PaymentType;
 import com.jvnlee.catchdining.domain.payment.dto.ReserveMenuDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class ReservationDto {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/reservation/dto/ReservationRestaurantViewDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/reservation/dto/ReservationRestaurantViewDto.java
@@ -3,10 +3,12 @@ package com.jvnlee.catchdining.domain.reservation.dto;
 import com.jvnlee.catchdining.domain.reservation.model.Reservation;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class ReservationRestaurantViewDto {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/reservation/dto/ReservationUserViewDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/reservation/dto/ReservationUserViewDto.java
@@ -3,10 +3,12 @@ package com.jvnlee.catchdining.domain.reservation.dto;
 import com.jvnlee.catchdining.domain.reservation.model.Reservation;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class ReservationUserViewDto {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/seat/dto/SeatDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/seat/dto/SeatDto.java
@@ -3,11 +3,13 @@ package com.jvnlee.catchdining.domain.seat.dto;
 import com.jvnlee.catchdining.domain.seat.model.SeatType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
 import java.util.List;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class SeatDto {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/user/dto/JwtDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/dto/JwtDto.java
@@ -2,8 +2,10 @@ package com.jvnlee.catchdining.domain.user.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class JwtDto {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserLoginDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserLoginDto.java
@@ -2,8 +2,10 @@ package com.jvnlee.catchdining.domain.user.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class UserLoginDto {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserSearchDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserSearchDto.java
@@ -4,10 +4,12 @@ import com.jvnlee.catchdining.domain.user.model.User;
 import com.jvnlee.catchdining.entity.Favorite;
 import com.jvnlee.catchdining.entity.Review;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@NoArgsConstructor
 public class UserSearchDto {
 
     private String username;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,35 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/catch_dining
+    username: root
+    password: 1234
+
+  redis:
+    host: localhost
+    port: 6379
+
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+
+  sql:
+    init:
+      mode: always
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: debug
+        type: trace
+      springframework:
+        security: debug
+
+jwt:
+  secret: 5bc35db8b6c3725c3b1e767fbfccc78d6067abcdcb70fa3ce9973837351dab03
+  alg: HS256
+  access:
+    exp: 900000
+  refresh:
+    exp: 3600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: dev

--- a/src/test/java/com/jvnlee/catchdining/CatchdiningApplicationTests.java
+++ b/src/test/java/com/jvnlee/catchdining/CatchdiningApplicationTests.java
@@ -1,13 +1,12 @@
 package com.jvnlee.catchdining;
 
+import com.jvnlee.catchdining.util.IntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@ContextConfiguration(initializers = TestContextInitializer.class)
+@IntegrationTest
 class CatchdiningApplicationTests {
 
 	@Test

--- a/src/test/java/com/jvnlee/catchdining/CatchdiningApplicationTests.java
+++ b/src/test/java/com/jvnlee/catchdining/CatchdiningApplicationTests.java
@@ -2,8 +2,12 @@ package com.jvnlee.catchdining;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest
+@ActiveProfiles("test")
+@ContextConfiguration(initializers = TestContextInitializer.class)
 class CatchdiningApplicationTests {
 
 	@Test

--- a/src/test/java/com/jvnlee/catchdining/TestContextInitializer.java
+++ b/src/test/java/com/jvnlee/catchdining/TestContextInitializer.java
@@ -8,14 +8,25 @@ public class TestContextInitializer implements ApplicationContextInitializer<Con
 
     @Override
     public void initialize(ConfigurableApplicationContext applicationContext) {
-        GenericContainer redis = new GenericContainer("redis:7.0.14")
-                .withExposedPorts(6379)
-                .withReuse(true);
+        RedisContainerManager.start();
+    }
 
-        redis.start();
+    static class RedisContainerManager {
+        private static GenericContainer redis;
 
-        System.setProperty("spring.redis.host", redis.getHost());
-        System.setProperty("spring.redis.port", redis.getMappedPort(6379).toString());
+        private RedisContainerManager() {}
+
+        public static void start() {
+            if (redis == null) {
+                redis = new GenericContainer("redis:7.0.14")
+                        .withExposedPorts(6379);
+
+                redis.start();
+
+                System.setProperty("spring.redis.host", redis.getHost());
+                System.setProperty("spring.redis.port", redis.getMappedPort(6379).toString());
+            }
+        }
     }
 
 }

--- a/src/test/java/com/jvnlee/catchdining/TestContextInitializer.java
+++ b/src/test/java/com/jvnlee/catchdining/TestContextInitializer.java
@@ -1,0 +1,21 @@
+package com.jvnlee.catchdining;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public class TestContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        RedisContainer redis = new RedisContainer("redis:7.0.14")
+                .withExposedPorts(6379)
+                .withReuse(true);
+
+        redis.start();
+
+        System.setProperty("spring.redis.host", redis.getHost());
+        System.setProperty("spring.redis.port", redis.getMappedPort(6379).toString());
+    }
+
+}

--- a/src/test/java/com/jvnlee/catchdining/TestContextInitializer.java
+++ b/src/test/java/com/jvnlee/catchdining/TestContextInitializer.java
@@ -1,14 +1,14 @@
 package com.jvnlee.catchdining;
 
-import com.redis.testcontainers.RedisContainer;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.containers.GenericContainer;
 
 public class TestContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
     @Override
     public void initialize(ConfigurableApplicationContext applicationContext) {
-        RedisContainer redis = new RedisContainer("redis:7.0.14")
+        GenericContainer redis = new GenericContainer("redis:7.0.14")
                 .withExposedPorts(6379)
                 .withReuse(true);
 

--- a/src/test/java/com/jvnlee/catchdining/integration/FirebaseMessagingServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/FirebaseMessagingServiceTest.java
@@ -1,21 +1,27 @@
-package com.jvnlee.catchdining.domain.notification.service;
+package com.jvnlee.catchdining.integration;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.jvnlee.catchdining.TestContextInitializer;
 import com.jvnlee.catchdining.common.exception.MessageSendingFailureException;
+import com.jvnlee.catchdining.domain.notification.service.FirebaseMessagingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
+@ActiveProfiles("test")
+@ContextConfiguration(initializers = TestContextInitializer.class)
 @EnableRetry
 public class FirebaseMessagingServiceTest {
 

--- a/src/test/java/com/jvnlee/catchdining/integration/FirebaseMessagingServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/FirebaseMessagingServiceTest.java
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.Message;
 import com.jvnlee.catchdining.TestContextInitializer;
 import com.jvnlee.catchdining.common.exception.MessageSendingFailureException;
 import com.jvnlee.catchdining.domain.notification.service.FirebaseMessagingService;
+import com.jvnlee.catchdining.util.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,9 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@ContextConfiguration(initializers = TestContextInitializer.class)
+@IntegrationTest
 @EnableRetry
 public class FirebaseMessagingServiceTest {
 

--- a/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
@@ -231,5 +231,17 @@ class LoginIntegrationTest {
                 .body("message", equalTo("Authorization header의 형식이 올바르지 않습니다."));
     }
 
+    @Test
+    @DisplayName("JWT 로그인 실패: Scheme이 Bearer가 아닌 유효하지 않은 Authorization 헤더")
+    void jwt_login_fail_invalid_scheme() {
+        RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, "WrongScheme ... ...")
+                .get("/someUrl")
+                .then().log().all()
+                .assertThat()
+                .statusCode(BAD_REQUEST.value())
+                .body("message", equalTo("Authorization header의 scheme이 올바르지 않습니다."));
+    }
 
 }

--- a/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
@@ -3,6 +3,7 @@ package com.jvnlee.catchdining.integration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jvnlee.catchdining.domain.user.dto.UserDto;
 import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
+import com.jvnlee.catchdining.domain.user.repository.UserRepository;
 import com.jvnlee.catchdining.domain.user.service.UserService;
 import com.jvnlee.catchdining.TestContextInitializer;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,16 +33,34 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Transactional
 @ActiveProfiles("test")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(initializers = TestContextInitializer.class)
 class LoginIntegrationTest {
 
-    @Autowired
-    MockMvc mockMvc;
+    @LocalServerPort
+    int port;
 
     @Autowired
     ObjectMapper om;
 
     @Autowired
+    UserRepository userRepository;
+
+    @Autowired
     UserService userService;
+
+    @BeforeEach
+    void beforeEach() {
+        RestAssured.port = port;
+
+        UserDto userDto = new UserDto("andy", "12345", "01012345678", CUSTOMER);
+        userService.join(userDto);
+    }
+
+    @AfterEach
+    void afterEach() {
+        userRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("username password 로그인 성공")

--- a/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-@TestPropertySource(locations = "file:src/test/resources/application.properties")
+@ActiveProfiles("test")
 class LoginIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
@@ -6,34 +6,29 @@ import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
 import com.jvnlee.catchdining.domain.user.repository.UserRepository;
 import com.jvnlee.catchdining.domain.user.service.UserService;
 import com.jvnlee.catchdining.TestContextInitializer;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.transaction.annotation.Transactional;
 
 import static com.jvnlee.catchdining.domain.user.model.UserType.*;
-import static java.nio.charset.StandardCharsets.*;
-import static org.assertj.core.api.Assertions.*;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.*;
 import static org.springframework.http.HttpHeaders.*;
-import static org.springframework.http.MediaType.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.http.HttpStatus.*;
 
-@SpringBootTest
-@ContextConfiguration(initializers = TestContextInitializer.class)
-@AutoConfigureMockMvc
-@Transactional
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
 @ContextConfiguration(initializers = TestContextInitializer.class)
 class LoginIntegrationTest {
 
@@ -65,195 +60,175 @@ class LoginIntegrationTest {
     @Test
     @DisplayName("username password 로그인 성공")
     void login_success() throws Exception {
-        UserDto userDto = new UserDto("user", "12345", "01012345678", CUSTOMER);
-        userService.join(userDto);
-
-        UserLoginDto userLoginDto = new UserLoginDto("user", "12345");
+        UserLoginDto userLoginDto = new UserLoginDto("andy", "12345");
         String requestBody = om.writeValueAsString(userLoginDto);
 
-        ResultActions resultActions = mockMvc.perform(
-                post("/login")
-                        .contentType(APPLICATION_JSON)
-                        .characterEncoding(UTF_8)
-                        .content(requestBody)
-        );
-
-        String responseAuthHeader = resultActions.andReturn().getResponse().getHeader(AUTHORIZATION);
-        assertThat(responseAuthHeader).startsWith("Bearer");
-        assertThat(responseAuthHeader.split(" ").length).isEqualTo(3);
-        resultActions.andExpect(status().isOk());
+        RestAssured
+                .given().log().all()
+                .body(requestBody)
+                .contentType(JSON)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .assertThat()
+                .statusCode(OK.value())
+                .header(AUTHORIZATION, startsWith("Bearer"))
+                .header(AUTHORIZATION, (header) -> header.split(" ").length, equalTo(3));
     }
 
     @Test
     @DisplayName("username password 로그인 실패: 잘못된 username")
     void login_fail_username() throws Exception {
-        UserDto userDto = new UserDto("user", "12345", "01012345678", CUSTOMER);
-        userService.join(userDto);
-
         UserLoginDto userLoginDto = new UserLoginDto("wrong", "12345");
         String requestBody = om.writeValueAsString(userLoginDto);
 
-        ResultActions resultActions = mockMvc.perform(
-                post("/login")
-                        .contentType(APPLICATION_JSON)
-                        .characterEncoding(UTF_8)
-                        .content(requestBody)
-        );
-
-        resultActions
-                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."))
-                .andExpect(status().isNotFound());
+        RestAssured
+                .given().log().all()
+                .body(requestBody)
+                .contentType(JSON)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .assertThat()
+                .statusCode(BAD_REQUEST.value())
+                .body("message", equalTo("존재하지 않는 사용자입니다."));
     }
 
     @Test
     @DisplayName("username password 로그인 실패: 잘못된 password")
     void login_fail_password() throws Exception {
-        UserDto userDto = new UserDto("user", "12345", "01012345678", CUSTOMER);
-        userService.join(userDto);
-
-        UserLoginDto userLoginDto = new UserLoginDto("user", "wrong");
+        UserLoginDto userLoginDto = new UserLoginDto("andy", "wrong");
         String requestBody = om.writeValueAsString(userLoginDto);
 
-        ResultActions resultActions = mockMvc.perform(
-                post("/login")
-                        .contentType(APPLICATION_JSON)
-                        .characterEncoding(UTF_8)
-                        .content(requestBody)
-        );
-
-        resultActions
-                .andExpect(jsonPath("$.message").value("비밀번호가 올바르지 않습니다."))
-                .andExpect(status().isBadRequest());
+        RestAssured
+                .given().log().all()
+                .body(requestBody)
+                .contentType(JSON)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .assertThat()
+                .statusCode(BAD_REQUEST.value())
+                .body("message", equalTo("비밀번호가 올바르지 않습니다."));
     }
 
     @Test
     @DisplayName("JWT 로그인 성공: Access(Valid) + Refresh(Valid)")
     void jwt_login_case_1() throws Exception {
-        UserDto userDto = new UserDto("user", "12345", "01012345678", CUSTOMER);
-        userService.join(userDto);
-
-        UserLoginDto userLoginDto = new UserLoginDto("user", "12345");
+        UserLoginDto userLoginDto = new UserLoginDto("andy", "12345");
         String requestBody = om.writeValueAsString(userLoginDto);
 
-        ResultActions usernamePasswordLoginAction = mockMvc.perform(
-                post("/login")
-                        .contentType(APPLICATION_JSON)
-                        .characterEncoding(UTF_8)
-                        .content(requestBody)
-        );
-
-        String authHeader = usernamePasswordLoginAction.andReturn().getResponse().getHeader(AUTHORIZATION);
-
-        ResultActions jwtLoginAction = mockMvc.perform(
-                get("/someUrl")
-                        .header(AUTHORIZATION, authHeader)
-        );
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .body(requestBody)
+                .contentType(JSON)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .extract();
 
         /*
-         존재하지 않는 임의의 URL에 대한 GET 요청을 했을 때,
-         403: 인증/인가가 안되었음
-         404: 인증/인가는 되었으나 리소스가 존재하지 않음
+         임의의 URL에 대한 GET 요청을 했을 때,
+         401: 인증이 안되었음
+         404: 인증은 되었으나 리소스가 존재하지 않음
          */
-        jwtLoginAction.andExpect(status().isNotFound());
+        RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, response.header(AUTHORIZATION))
+                .when()
+                .get("/someUrl")
+                .then().log().all()
+                .assertThat()
+                .statusCode(NOT_FOUND.value());
     }
 
     @Test
     @DisplayName("JWT 로그인 성공: Access(Valid) + Refresh(Invalid)")
     void jwt_login_case_2() throws Exception {
-        UserDto userDto = new UserDto("user", "12345", "01012345678", CUSTOMER);
-        userService.join(userDto);
-
-        UserLoginDto userLoginDto = new UserLoginDto("user", "12345");
+        UserLoginDto userLoginDto = new UserLoginDto("andy", "12345");
         String requestBody = om.writeValueAsString(userLoginDto);
 
-        ResultActions usernamePasswordLoginAction = mockMvc.perform(
-                post("/login")
-                        .contentType(APPLICATION_JSON)
-                        .characterEncoding(UTF_8)
-                        .content(requestBody)
-        );
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .body(requestBody)
+                .contentType(JSON)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .extract();
 
-        String authHeader = usernamePasswordLoginAction.andReturn().getResponse().getHeader(AUTHORIZATION);
-        String[] split = authHeader.split(" ");
-        String authHeaderWithInvalidRefreshToken = split[0] + " " + split[1] + " " + "InvalidRefreshToken";
+        String validAccessToken = response.header(AUTHORIZATION).split(" ")[1];
 
-        ResultActions jwtLoginAction = mockMvc.perform(
-                get("/someUrl")
-                        .header(AUTHORIZATION, authHeaderWithInvalidRefreshToken)
-        );
-
-        jwtLoginAction.andExpect(status().isNotFound()); // Refresh Token과 관계 없이 인증/인가 처리
+        RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, "Bearer " + validAccessToken + " " + "InvalidRefreshToken")
+                .get("/someUrl")
+                .then().log().all()
+                .assertThat()
+                .statusCode(NOT_FOUND.value()); // Refresh Token과 관계 없이 인증 처리
     }
 
     @Test
-    @DisplayName("JWT 로그인 성공: Access(Invalid) + Refresh(Valid)")
+    @DisplayName("JWT 로그인 실패: Access(Invalid) + Refresh(Valid)")
     void jwt_login_case_3() throws Exception {
-        UserDto userDto = new UserDto("user", "12345", "01012345678", CUSTOMER);
-        userService.join(userDto);
-
-        UserLoginDto userLoginDto = new UserLoginDto("user", "12345");
+        UserLoginDto userLoginDto = new UserLoginDto("andy", "12345");
         String requestBody = om.writeValueAsString(userLoginDto);
 
-        ResultActions usernamePasswordLoginAction = mockMvc.perform(
-                post("/login")
-                        .contentType(APPLICATION_JSON)
-                        .characterEncoding(UTF_8)
-                        .content(requestBody)
-        );
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .body(requestBody)
+                .contentType(JSON)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .extract();
 
-        String authHeader = usernamePasswordLoginAction.andReturn().getResponse().getHeader(AUTHORIZATION);
+        String authHeader = response.header(AUTHORIZATION);
+        String validRefreshToken = authHeader.split(" ")[2];
 
-        Thread.sleep(5000); // 테스트 환경에서는 Access Token의 만료 기한을 3초로 잡아놓음 (만료시키기 위해 잠시 대기)
-
-        ResultActions jwtLoginAction = mockMvc.perform(
-                get("/someUrl")
-                        .header(AUTHORIZATION, authHeader)
-        );
-
-        String newAuthHeader = jwtLoginAction.andReturn().getResponse().getHeader(AUTHORIZATION);
-        assertThat(newAuthHeader).isNotEqualTo(authHeader); // Access Token이 재발급되었으므로 두 헤더가 같으면 안됨
-        jwtLoginAction.andExpect(status().isNotFound()); // 재발급과 동시에 인증 처리시키므로 404 응답
+        RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, "Bearer InvalidRefreshToken " + validRefreshToken)
+                .get("/someUrl")
+                .then().log().all()
+                .assertThat()
+                .statusCode(NOT_FOUND.value());
     }
 
     @Test
     @DisplayName("JWT 로그인 실패: Access(Invalid) + Refresh(Invalid)")
     void jwt_login_case_4() throws Exception {
-        UserDto userDto = new UserDto("user", "12345", "01012345678", CUSTOMER);
-        userService.join(userDto);
-
-        UserLoginDto userLoginDto = new UserLoginDto("user", "12345");
+        UserLoginDto userLoginDto = new UserLoginDto("andy", "12345");
         String requestBody = om.writeValueAsString(userLoginDto);
 
-        ResultActions usernamePasswordLoginAction = mockMvc.perform(
-                post("/login")
-                        .contentType(APPLICATION_JSON)
-                        .characterEncoding(UTF_8)
-                        .content(requestBody)
-        );
+        RestAssured
+                .given().log().all()
+                .body(requestBody)
+                .contentType(JSON)
+                .when()
+                .post("/login")
+                .then().log().all();
 
-        String authHeader = usernamePasswordLoginAction.andReturn().getResponse().getHeader(AUTHORIZATION);
-
-        Thread.sleep(10000); // 두 토큰 모두 만료시키기 위해 10초 대기 (Access 3초, Refresh 6초)
-
-        ResultActions jwtLoginAction = mockMvc.perform(
-                get("/someUrl")
-                        .header(AUTHORIZATION, authHeader)
-        );
-
-        jwtLoginAction.andExpect(status().isForbidden()); // 인증/인가 실패로 403 응답
+        RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, "Bearer InvalidAccessToken InvalidRefreshToken")
+                .get("/someUrl")
+                .then().log().all()
+                .assertThat()
+                .statusCode(UNAUTHORIZED.value());
     }
 
     @Test
-    @DisplayName("JWT 로그인 실패: 잘못된 Authorization 헤더")
-    void jwt_login_fail_invalid_header() throws Exception {
-        String authHeader = "Invalid Auth Header";
-
-        ResultActions jwtLoginAction = mockMvc.perform(
-                get("/someUrl")
-                        .header(AUTHORIZATION, authHeader)
-        );
-
-        jwtLoginAction.andExpect(status().isBadRequest()); // JwtExceptionFilter에 의해 400 응답
+    @DisplayName("JWT 로그인 실패: 3단 구조가 아닌 유효하지 않은 Authorization 헤더")
+    void jwt_login_fail_invalid_header_structure() {
+        RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, "Invalid Auth Header 123123")
+                .get("/someUrl")
+                .then().log().all()
+                .assertThat()
+                .statusCode(BAD_REQUEST.value()) // JwtExceptionFilter에 의해 400 응답
+                .body("message", equalTo("Authorization header의 형식이 올바르지 않습니다."));
     }
 
 

--- a/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
@@ -6,6 +6,7 @@ import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
 import com.jvnlee.catchdining.domain.user.repository.UserRepository;
 import com.jvnlee.catchdining.domain.user.service.UserService;
 import com.jvnlee.catchdining.TestContextInitializer;
+import com.jvnlee.catchdining.util.IntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -27,9 +28,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpStatus.*;
 
-@ActiveProfiles("test")
-@SpringBootTest(webEnvironment = RANDOM_PORT)
-@ContextConfiguration(initializers = TestContextInitializer.class)
+@IntegrationTest
 class LoginIntegrationTest {
 
     @LocalServerPort

--- a/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jvnlee.catchdining.domain.user.dto.UserDto;
 import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
 import com.jvnlee.catchdining.domain.user.service.UserService;
+import com.jvnlee.catchdining.TestContextInitializer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@ContextConfiguration(initializers = TestContextInitializer.class)
 @AutoConfigureMockMvc
 @Transactional
 @ActiveProfiles("test")

--- a/src/test/java/com/jvnlee/catchdining/integration/ReservationIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/ReservationIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.integration;
 
+import com.jvnlee.catchdining.TestContextInitializer;
 import com.jvnlee.catchdining.domain.menu.dto.MenuDto;
 import com.jvnlee.catchdining.domain.menu.service.MenuService;
 import com.jvnlee.catchdining.domain.payment.model.PaymentType;
@@ -25,6 +26,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -36,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@ContextConfiguration(initializers = TestContextInitializer.class)
 class ReservationIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/jvnlee/catchdining/integration/ReservationIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/ReservationIntegrationTest.java
@@ -18,6 +18,7 @@ import com.jvnlee.catchdining.domain.seat.service.SeatService;
 import com.jvnlee.catchdining.domain.user.dto.UserDto;
 import com.jvnlee.catchdining.domain.user.model.UserType;
 import com.jvnlee.catchdining.domain.user.service.UserService;
+import com.jvnlee.catchdining.util.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,9 +37,7 @@ import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@ContextConfiguration(initializers = TestContextInitializer.class)
+@IntegrationTest
 class ReservationIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/jvnlee/catchdining/integration/ReservationIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/ReservationIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -34,6 +35,7 @@ import java.util.concurrent.Executors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ReservationIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/jvnlee/catchdining/util/IntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/util/IntegrationTest.java
@@ -1,0 +1,21 @@
+package com.jvnlee.catchdining.util;
+
+import com.jvnlee.catchdining.TestContextInitializer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.*;
+
+@Target(TYPE)
+@Retention(RUNTIME)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("test")
+@ContextConfiguration(initializers = TestContextInitializer.class)
+public @interface IntegrationTest {
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,30 @@
+spring:
+  datasource:
+    url: jdbc:tc:mysql:8.0.32://localhost:3306/catch_dining
+    username: root
+    password: 1234
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: debug
+        type: trace
+      springframework:
+        security: debug
+
+jwt:
+  secret: 5bc35db8b6c3725c3b1e767fbfccc78d6067abcdcb70fa3ce9973837351dab03
+  alg: HS256
+  access:
+    exp: 3000
+  refresh:
+    exp: 6000


### PR DESCRIPTION
## 구현 내용

### 1. 독립적인 테스트 Profile 사용을 위해 프로젝트에 Profile 기반의 YML 생성

GitHub에는 application-dev.yml과 application-test.yml 2개의 Profile 설정만 외부에 노출함

> dev는 개발 환경에서, test는 테스트 환경에서만 사용하며, 공개하지 않은 prod Profile은 배포 환경에서 사용함

&nbsp;

### 2. TestContainers로 테스트 실행 환경 일반화

기존에는 임의의 로컬 환경에서 테스트 코드를 실행하기 위해서 MySQL과 Redis의 별도 설치와 실행이 요구되었음

#### 💡 테스트용 MySQL의 대안

1) H2 Database

    장점:
    - In-Memory 방식으로 매우 가벼움
    
    - 의존성 추가 후 복잡한 별도 세팅이 필요 없음
    
    - MySQL 모드로 실제 DB인 MySQL과 유사하게 사용할 수 있음

    단점:
    - 운영 DB가 바뀌었을 때도 항상 유사성을 보장해주지는 않음
    
    - 특정 DB의 기능을 지원하지 않는 경우 테스트가 어려움

&nbsp;

2) Docker MySQL Container

    장점:
    - 동일한 규격(동일한 버전과 설정을 가진 MySQL)으로 실행 가능

    단점:
    - 테스트 코드를 실행하려는 임의의 로컬 사용자가 Docker에 대한 지식이 없다면 선수 학습이 필요할 수 있음
    
    - Docker 설치 및 docker-compose 작성 등의 별도 세팅이 필요함

&nbsp;

#### 💡 테스트용 Redis의 대안

1) Embedded Redis

    장점:
    - H2처럼 앱 실행 시 내부에서 Redis를 실행하기 때문에 외부 설치나 실행이 필요 없음

    단점:
    - 오픈소스인데 마지막 업데이트가 kstyrc/embedded-redis 기준 6년전 (지속성이 불투명함)
    
        > 파생된 소스인 codemonstur/embedded-redis는 2개월 전 업데이트로 최신이긴 하지만 이 또한 언제 끊길지 알 수 없음...
    
    - 별도 Config로 실행과 중지 과정에 대한 세팅이 필요함

2) Docker Redis Container

    Docker MySQL Container 활용의 장단점과 동일

&nbsp;

#### 💡 최종 선택지: TestContainers

결국 H2나 Embedded Redis처럼 내장형으로 갈 것이냐, 아니면 Docker처럼 외부 컨테이너형으로 갈 것이냐를 두고 고민해야했음. 

장단점을 놓고 봤을 때, Docker에 대한 지식만 있다면 후자가 더 낫다고 판단함. 본인은 Docker를 학습한 상태기 때문에 상관 없지만, 랜덤한 테스트 실행자가 Docker를 잘 모른다면 여전히 문제가 있을 수 있다고 생각했음.

이 때, 보다 쉽게 Docker Container 기반 테스트 환경을 구축할 수 있도록 도와주는 TestContainers라는 라이브러리가 있어서 이를 채택하게 됨.

&nbsp;

장점:
- 사용할 서비스를 직접 컨테이너화 할 필요가 없음 (Docker에 대한 지식이 없어도 괜찮음)
- 세팅 방식이 단순함
- 테스트 시작과 종료시 자동으로 컨테이너가 실행되고 중지됨

단점:
- Redis를 공식 지원하지 않음

    > 이 때문에 Redis 세팅에 약간 번거로움이 있었지만 해결됨 &#8594; `TestContextInitializer`

&nbsp;

`TestContextInitializer`: ApplicationContext의 초기화 로직을 커스터마이즈

> Redis TestContainer는 실행될 때마다 바인딩된 포트 번호가 달라지기 때문에 이를 런타임에 받아와서 System Property로 지정
> 
> System Property에 저장된 포트 번호가 RedisConfig의 port 필드에 주입됨 &#8594; 해당 정보를 바탕으로 Application Context 생성

&nbsp;

### 3. RestAssured로 E2E 통합테스트의 실용성 강화

기존 `@MockMvc`를 활용하는 방식은 가상 MVC, 즉 가상 환경에 가까운 방식이라서 실제 API의 동작을 테스트하기에는 부족한 면이 있었음.
> `@MockMvc`는 컨트롤러의 단위 테스트에 좀 더 적합함

이 때문에 Postman 같은 외부 앱을 사용해서 부족한 E2E 테스트를 수동으로 커버중이었는데 매우 불편했음.

REST Assured라는 라이브러리를 도입해서 코드 레벨에서 E2E 테스트를 커버하고자 함.

&nbsp;

장점:
- HTTP Endpoint에 초점을 맞추고 있어 모든 계층의 로직을 거치는 통합테스트를 하기에 용이함

- given, when, then의 구조를 제공해서 테스트 코드의 가독성이 좋음

- 내장 assertion을 메서드 체이닝으로 활용할 수 있어 AssertJ 등으로 검증 로직을 따로 넣을 필요가 없음