### PR TITLE
feature/#39 query logging for optimization

### DIFF
--- a/src/main/java/com/jvnlee/catchdining/common/config/HibernateConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/HibernateConfig.java
@@ -1,0 +1,22 @@
+package com.jvnlee.catchdining.common.config;
+
+import com.jvnlee.catchdining.common.util.QueryInspector;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.hibernate.cfg.AvailableSettings.STATEMENT_INSPECTOR;
+
+@Configuration
+@RequiredArgsConstructor
+public class HibernateConfig {
+
+    private final QueryInspector queryInspector;
+
+    @Bean
+    public HibernatePropertiesCustomizer configureStatementInspector() {
+        return hibernateProperties -> hibernateProperties.put(STATEMENT_INSPECTOR, queryInspector);
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/common/config/HibernateConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/HibernateConfig.java
@@ -5,9 +5,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import static org.hibernate.cfg.AvailableSettings.STATEMENT_INSPECTOR;
 
+@Profile("dev")
 @Configuration
 @RequiredArgsConstructor
 public class HibernateConfig {

--- a/src/main/java/com/jvnlee/catchdining/common/config/WebMvcConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package com.jvnlee.catchdining.common.config;
+
+import com.jvnlee.catchdining.common.interceptor.QueryLoggingInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final QueryLoggingInterceptor queryLoggingInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(queryLoggingInterceptor);
+    }
+}

--- a/src/main/java/com/jvnlee/catchdining/common/config/WebMvcConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/WebMvcConfig.java
@@ -3,9 +3,11 @@ package com.jvnlee.catchdining.common.config;
 import com.jvnlee.catchdining.common.interceptor.QueryLoggingInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Profile("dev")
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {

--- a/src/main/java/com/jvnlee/catchdining/common/interceptor/QueryLoggingInterceptor.java
+++ b/src/main/java/com/jvnlee/catchdining/common/interceptor/QueryLoggingInterceptor.java
@@ -1,0 +1,54 @@
+package com.jvnlee.catchdining.common.interceptor;
+
+import com.jvnlee.catchdining.common.util.QueryInspector;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueryLoggingInterceptor implements HandlerInterceptor {
+
+    private final QueryInspector queryInspector;
+
+    private static final String QUERY_LOG_INFO_FORMAT = "\n" +
+            "- HTTP Method: {}\n" +
+            "- URI: {}\n" +
+            "- Elapsed Time: {}ms\n" +
+            "- Query Execution Count: {}";
+
+    private static final String QUERY_LOG_WARN_FORMAT = "\n" +
+            "쿼리가 실행 횟수가 기준치 {}회를 초과했습니다.\n" +
+            "- Query Execution Count: {}";
+
+    private static final int QUERY_LOG_WARN_THRESHOLD = 10;
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
+                                 @Nullable Exception ex) throws Exception {
+        Long elapsedTime = queryInspector.getElapsedTime();
+        int executionCount = queryInspector.getExecutionCount();
+
+        log.info(
+            QUERY_LOG_INFO_FORMAT,
+            request.getMethod(),
+            request.getRequestURI(),
+            elapsedTime,
+            executionCount
+        );
+
+        if (executionCount >= QUERY_LOG_WARN_THRESHOLD) {
+            log.warn(
+                QUERY_LOG_WARN_FORMAT,
+                QUERY_LOG_WARN_THRESHOLD,
+                executionCount
+            );
+        }
+    }
+}

--- a/src/main/java/com/jvnlee/catchdining/common/interceptor/QueryLoggingInterceptor.java
+++ b/src/main/java/com/jvnlee/catchdining/common/interceptor/QueryLoggingInterceptor.java
@@ -3,6 +3,7 @@ package com.jvnlee.catchdining.common.interceptor;
 import com.jvnlee.catchdining.common.util.QueryInspector;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -11,6 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Slf4j
+@Profile("dev")
 @Component
 @RequiredArgsConstructor
 public class QueryLoggingInterceptor implements HandlerInterceptor {

--- a/src/main/java/com/jvnlee/catchdining/common/util/QueryInspector.java
+++ b/src/main/java/com/jvnlee/catchdining/common/util/QueryInspector.java
@@ -3,10 +3,12 @@ package com.jvnlee.catchdining.common.util;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
 @Slf4j
+@Profile("dev")
 @Component
 @RequestScope
 @Getter

--- a/src/main/java/com/jvnlee/catchdining/common/util/QueryInspector.java
+++ b/src/main/java/com/jvnlee/catchdining/common/util/QueryInspector.java
@@ -1,13 +1,11 @@
 package com.jvnlee.catchdining.common.util;
 
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
-@Slf4j
 @Profile("dev")
 @Component
 @RequestScope

--- a/src/main/java/com/jvnlee/catchdining/common/util/QueryInspector.java
+++ b/src/main/java/com/jvnlee/catchdining/common/util/QueryInspector.java
@@ -1,0 +1,29 @@
+package com.jvnlee.catchdining.common.util;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Slf4j
+@Component
+@RequestScope
+@Getter
+public class QueryInspector implements StatementInspector {
+
+    private final Long requestStartTime = System.currentTimeMillis();
+
+    private int executionCount;
+
+    public Long getElapsedTime() {
+        return System.currentTimeMillis() - requestStartTime;
+    }
+
+    @Override
+    public String inspect(String sql) {
+        executionCount++;
+        return sql;
+    }
+
+}

--- a/src/test/java/com/jvnlee/catchdining/domain/menu/controller/MenuControllerTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/menu/controller/MenuControllerTest.java
@@ -1,6 +1,5 @@
 package com.jvnlee.catchdining.domain.menu.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jvnlee.catchdining.domain.menu.dto.MenuDto;
 import com.jvnlee.catchdining.domain.menu.dto.MenuViewDto;
@@ -14,19 +13,18 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static java.nio.charset.StandardCharsets.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@ActiveProfiles("test")
 @WebMvcTest(
         controllers = {MenuController.class},
         excludeAutoConfiguration = SecurityAutoConfiguration.class

--- a/src/test/java/com/jvnlee/catchdining/domain/notification/controller/NotificationRequestControllerTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/notification/controller/NotificationRequestControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -23,13 +24,13 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static com.jvnlee.catchdining.domain.notification.model.DiningPeriod.LUNCH;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @WebMvcTest(
         controllers = {NotificationRequestController.class},
         excludeAutoConfiguration = SecurityAutoConfiguration.class

--- a/src/test/java/com/jvnlee/catchdining/domain/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/reservation/controller/ReservationControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -26,13 +27,13 @@ import java.util.List;
 import static com.jvnlee.catchdining.domain.payment.model.PaymentType.CREDIT_CARD;
 import static com.jvnlee.catchdining.domain.reservation.model.ReservationStatus.RESERVED;
 import static com.jvnlee.catchdining.domain.reservation.model.ReservationStatus.VISITED;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @WebMvcTest(
         controllers = {ReservationController.class},
         excludeAutoConfiguration = SecurityAutoConfiguration.class

--- a/src/test/java/com/jvnlee/catchdining/domain/restaurant/controller/RestaurantControllerTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/restaurant/controller/RestaurantControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -32,6 +33,7 @@ import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@ActiveProfiles("test")
 @WebMvcTest(
         controllers = {RestaurantController.class},
         excludeAutoConfiguration = SecurityAutoConfiguration.class

--- a/src/test/java/com/jvnlee/catchdining/domain/seat/controller/SeatControllerTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/seat/controller/SeatControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @WebMvcTest(
         controllers = {SeatController.class},
         excludeAutoConfiguration = SecurityAutoConfiguration.class


### PR DESCRIPTION
## 구현 내용

각 요청에서의 쿼리의 실행 횟수와 요청 처리 소요 시간을 로깅하는 기능을 구현함

&nbsp;

### QueryInspector

Hibernate의 `StatementInspector`를 구현해서 SQL 실행 시 이 Bean을 거치도록 함

`@RequestScope`를 사용해서 스프링 컨테이너에 요청이 들어와서 처리 후 응답으로 나가기까지를 life-cycle로 설정함

> 처음에는 `ThreadLocal`을 사용하는 방식을 고려했으나, 데이터와 요청의 life-cycle을 직접 일치시키는 것보다 Bean Scope를 적용하는 것이 실수할 우려도 적고 코드도 간소함

- `getElapsedTime()`: 요청 처리 소요 시간을 반환함

- `inspect()`: 쿼리가 실행될 때마다 횟수를 누적해서 저장함

&nbsp;

### QueryLoggingInterceptor

Spring의 `HandlerInterceptor`를 구현해서 요청의 후처리로 로깅 기능을 등록함

> 파생된 문제: `@WebMvcTest`를 사용하는 컨트롤러 단위 테스트 실패 &#8594; [관련 커밋](https://github.com/jvnlee/catch-dining/pull/40/commits/e443fc75d8e11cfddab8384dcddbe2ba44c98019)

REST API 서버이기 때문에 View Rendering을 하지 않아도 돼서 `postHandle()`과 `afterCompletion()` 둘 중 어느 곳에 로직을 넣어도 동작은 비슷할 것이라고 생각했음

그러나 조사 결과, 요청 처리 과정에서 예외가 발생하면 `postHandle()`은 호출되지 않는 대신, `afterCompletion()`은 반드시 호출이 보장되기 때문에 후자 쪽에 구현함

- `afterCompletion()`: 쿼리 실행 횟수와 요청 처리 시간을 INFO 로그로 출력. 쿼리 실행 횟수가 기준치 이상이 되면 WARN 로그를 출력함

&nbsp;

## 의문점

`QueryInspector`를 Hibernate 속성에 등록할 때, 왜 YML에 속성으로 기재하는 방식이 인식되지 않는지?

> 이 때문에 `HibernateConfig` 클래스를 만들어야 했음 &#8594; [관련 커밋](https://github.com/jvnlee/catch-dining/commit/ef1b870d68a8a3a1f2a8be576b3db8c75730eb2e)

&nbsp;

## 확장 가능성

쿼리 실행 횟수를 세고, 처리 시간을 기록하는 기능을 일종의 Aspect로 간주해서 이 기능을 AOP로 풀어볼 수도 있을 것 같음

> Dynamic Proxy와 AOP 학습의 일환으로 구현을 시도해보면 좋을 것 같음