### PR TITLE
feature/#45 review api

### DIFF
--- a/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
+++ b/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
@@ -32,7 +32,7 @@ public class ControllerAdvice {
     }
 
     @ExceptionHandler(RestaurantNotFoundException.class)
-    @ResponseStatus(NOT_FOUND)
+    @ResponseStatus(BAD_REQUEST)
     public Response<Void> handleRestaurantNotFound() {
         return new Response<>("식당 정보가 존재하지 않습니다.");
     }

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/model/Restaurant.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/model/Restaurant.java
@@ -2,6 +2,7 @@ package com.jvnlee.catchdining.domain.restaurant.model;
 
 import com.jvnlee.catchdining.domain.menu.domain.Menu;
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantDto;
+import com.jvnlee.catchdining.domain.review.model.Review;
 import com.jvnlee.catchdining.domain.seat.model.Seat;
 import com.jvnlee.catchdining.entity.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/jvnlee/catchdining/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/controller/ReviewController.java
@@ -1,0 +1,50 @@
+package com.jvnlee.catchdining.domain.review.controller;
+
+import com.jvnlee.catchdining.common.web.Response;
+import com.jvnlee.catchdining.domain.review.dto.ReviewCreateRequestDto;
+import com.jvnlee.catchdining.domain.review.dto.ReviewViewByRestaurantResponseDto;
+import com.jvnlee.catchdining.domain.review.dto.ReviewViewByUserResponseDto;
+import com.jvnlee.catchdining.domain.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping("/restaurants/{restaurantId}/reviews")
+    public Response<Void> create(@RequestBody ReviewCreateRequestDto reviewCreateRequestDto) {
+        reviewService.create(reviewCreateRequestDto);
+        return new Response<>("리뷰 등록 성공");
+    }
+
+    @GetMapping("/users/{userId}/reviews")
+    public Response<List<ReviewViewByUserResponseDto>> viewByUser(@PathVariable Long userId) {
+        List<ReviewViewByUserResponseDto> data = reviewService.viewByUser(userId);
+        return new Response<>("유저가 작성한 리뷰 조회 결과", data);
+    }
+
+    @GetMapping("/restaurants/{restaurantId}/reviews")
+    public Response<List<ReviewViewByRestaurantResponseDto>> viewByRestaurant(@PathVariable Long restaurantId) {
+        List<ReviewViewByRestaurantResponseDto> data = reviewService.viewByRestaurant(restaurantId);
+        return new Response<>("식당에 등록된 리뷰 조회 결과", data);
+    }
+
+    @DeleteMapping("/users/{userId}/reviews/{reviewId}")
+    public Response<Void> delete(@PathVariable Long userId, @PathVariable Long reviewId) {
+        reviewService.delete(reviewId);
+        return new Response<>("리뷰 삭제 성공");
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewCreateRequestDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewCreateRequestDto.java
@@ -1,0 +1,22 @@
+package com.jvnlee.catchdining.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewCreateRequestDto {
+
+    private Long restaurantId;
+
+    private double tasteRating;
+
+    private double moodRating;
+
+    private double serviceRating;
+
+    private String content;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByRestaurantResponseDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByRestaurantResponseDto.java
@@ -1,0 +1,30 @@
+package com.jvnlee.catchdining.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewViewByRestaurantResponseDto {
+
+    private Long reviewId;
+
+    private String username;
+
+    private LocalDate createdDate;
+
+    private double tasteRating;
+
+    private double moodRating;
+
+    private double serviceRating;
+
+    private String content;
+
+    private int commentCount;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByRestaurantResponseDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByRestaurantResponseDto.java
@@ -27,4 +27,17 @@ public class ReviewViewByRestaurantResponseDto {
 
     private int commentCount;
 
+    public ReviewViewByRestaurantResponseDto(ReviewViewByRestaurantResultDto r) {
+        this(
+                r.getReviewId(),
+                r.getUsername(),
+                r.getCreatedDate(),
+                r.getTasteRating(),
+                r.getMoodRating(),
+                r.getServiceRating(),
+                r.getContent(),
+                r.getCommentCount()
+        );
+    }
+
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByRestaurantResultDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByRestaurantResultDto.java
@@ -1,0 +1,23 @@
+package com.jvnlee.catchdining.domain.review.dto;
+
+import java.time.LocalDate;
+
+public interface ReviewViewByRestaurantResultDto {
+
+    Long getReviewId();
+
+    String getUsername();
+
+    LocalDate getCreatedDate();
+
+    double getTasteRating();
+
+    double getMoodRating();
+
+    double getServiceRating();
+
+    String getContent();
+
+    int getCommentCount();
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByUserResponseDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByUserResponseDto.java
@@ -1,0 +1,30 @@
+package com.jvnlee.catchdining.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewViewByUserResponseDto {
+
+    private Long reviewId;
+
+    private String restaurantName;
+
+    private LocalDate createdDate;
+
+    private double tasteRating;
+
+    private double moodRating;
+
+    private double serviceRating;
+
+    private String content;
+
+    private int commentCount;
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByUserResponseDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByUserResponseDto.java
@@ -27,4 +27,17 @@ public class ReviewViewByUserResponseDto {
 
     private int commentCount;
 
+    public ReviewViewByUserResponseDto(ReviewViewByUserResultDto r) {
+        this(
+                r.getReviewId(),
+                r.getRestaurantName(),
+                r.getCreatedDate(),
+                r.getTasteRating(),
+                r.getMoodRating(),
+                r.getServiceRating(),
+                r.getContent(),
+                r.getCommentCount()
+        );
+    }
+
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByUserResultDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/dto/ReviewViewByUserResultDto.java
@@ -1,0 +1,23 @@
+package com.jvnlee.catchdining.domain.review.dto;
+
+import java.time.LocalDate;
+
+public interface ReviewViewByUserResultDto {
+
+    Long getReviewId();
+
+    String getRestaurantName();
+
+    LocalDate getCreatedDate();
+
+    double getTasteRating();
+
+    double getMoodRating();
+
+    double getServiceRating();
+
+    String getContent();
+
+    int getCommentCount();
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/review/model/Review.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/model/Review.java
@@ -2,6 +2,8 @@ package com.jvnlee.catchdining.domain.review.model;
 
 import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
 import com.jvnlee.catchdining.domain.user.model.User;
+import com.jvnlee.catchdining.entity.BaseEntity;
+import com.jvnlee.catchdining.entity.ReviewComment;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,5 +44,14 @@ public class Review extends BaseEntity {
 
     @OneToMany(mappedBy = "review")
     private List<ReviewComment> reviewComments = new ArrayList<>();
+
+    public Review(User user, Restaurant restaurant, double tasteRating, double moodRating, double serviceRating, String content) {
+        this.user = user;
+        this.restaurant = restaurant;
+        this.tasteRating = tasteRating;
+        this.moodRating = moodRating;
+        this.serviceRating = serviceRating;
+        this.content = content;
+    }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/review/model/Review.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/model/Review.java
@@ -1,4 +1,4 @@
-package com.jvnlee.catchdining.entity;
+package com.jvnlee.catchdining.domain.review.model;
 
 import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
 import com.jvnlee.catchdining.domain.user.model.User;

--- a/src/main/java/com/jvnlee/catchdining/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,31 @@
+package com.jvnlee.catchdining.domain.review.repository;
+
+import com.jvnlee.catchdining.domain.review.dto.ReviewViewByRestaurantResultDto;
+import com.jvnlee.catchdining.domain.review.dto.ReviewViewByUserResultDto;
+import com.jvnlee.catchdining.domain.review.model.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @Query("select rv.id as reviewId, rv.restaurant.name as restaurantName, date(rv.createdDate) as createdDate, " +
+            "rv.tasteRating as tasteRating, rv.moodRating as moodRating, rv.serviceRating as serviceRating, " +
+            "rv.content as content, count(rvc.id) as commentCount " +
+            "from Review rv " +
+            "left join rv.reviewComments rvc " +
+            "where rv.user.id = :userId " +
+            "group by rv.id")
+    List<ReviewViewByUserResultDto> findAllByUserId(Long userId);
+
+    @Query("select rv.id as reviewId, rv.user.username as username, date(rv.createdDate) as createdDate, " +
+            "rv.tasteRating as tasteRating, rv.moodRating as moodRating, rv.serviceRating as serviceRating, " +
+            "rv.content as content, count(rvc.id) as commentCount " +
+            "from Review rv " +
+            "left join rv.reviewComments rvc " +
+            "where rv.restaurant.id = :restaurantId " +
+            "group by rv.id")
+    List<ReviewViewByRestaurantResultDto> findAllByRestaurantId(Long restaurantId);
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/review/service/ReviewService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/service/ReviewService.java
@@ -1,0 +1,70 @@
+package com.jvnlee.catchdining.domain.review.service;
+
+import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
+import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
+import com.jvnlee.catchdining.domain.restaurant.repository.RestaurantRepository;
+import com.jvnlee.catchdining.domain.review.dto.ReviewViewByRestaurantResponseDto;
+import com.jvnlee.catchdining.domain.review.dto.ReviewViewByUserResponseDto;
+import com.jvnlee.catchdining.domain.review.dto.ReviewCreateRequestDto;
+import com.jvnlee.catchdining.domain.review.model.Review;
+import com.jvnlee.catchdining.domain.review.repository.ReviewRepository;
+import com.jvnlee.catchdining.domain.user.model.User;
+import com.jvnlee.catchdining.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    private final RestaurantRepository restaurantRepository;
+
+    private final UserService userService;
+
+    public void create(ReviewCreateRequestDto reviewCreateRequestDto) {
+        User user = userService.getCurrentUser();
+        Restaurant restaurant = restaurantRepository
+                .findById(reviewCreateRequestDto.getRestaurantId())
+                .orElseThrow(RestaurantNotFoundException::new);
+
+        Review review = new Review(
+                user,
+                restaurant,
+                reviewCreateRequestDto.getTasteRating(),
+                reviewCreateRequestDto.getMoodRating(),
+                reviewCreateRequestDto.getServiceRating(),
+                reviewCreateRequestDto.getContent()
+        );
+
+        reviewRepository.save(review);
+    }
+
+    public List<ReviewViewByUserResponseDto> viewByUser(Long userId) {
+        return reviewRepository
+                .findAllByUserId(userId)
+                .stream()
+                .map(ReviewViewByUserResponseDto::new)
+                .collect(toList());
+    }
+
+    public List<ReviewViewByRestaurantResponseDto> viewByRestaurant(Long restaurantId) {
+        return reviewRepository
+                .findAllByRestaurantId(restaurantId)
+                .stream()
+                .map(ReviewViewByRestaurantResponseDto::new)
+                .collect(toList());
+    }
+
+    public void delete(Long reviewId) {
+        reviewRepository.deleteById(reviewId);
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserSearchDto.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/dto/UserSearchDto.java
@@ -2,7 +2,7 @@ package com.jvnlee.catchdining.domain.user.dto;
 
 import com.jvnlee.catchdining.domain.user.model.User;
 import com.jvnlee.catchdining.entity.Favorite;
-import com.jvnlee.catchdining.entity.Review;
+import com.jvnlee.catchdining.domain.review.model.Review;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/user/model/User.java
@@ -2,6 +2,7 @@ package com.jvnlee.catchdining.domain.user.model;
 
 import com.jvnlee.catchdining.domain.notification.model.NotificationRequest;
 import com.jvnlee.catchdining.domain.reservation.model.Reservation;
+import com.jvnlee.catchdining.domain.review.model.Review;
 import com.jvnlee.catchdining.domain.user.dto.UserDto;
 import com.jvnlee.catchdining.entity.*;
 import lombok.Getter;

--- a/src/main/java/com/jvnlee/catchdining/entity/ReviewComment.java
+++ b/src/main/java/com/jvnlee/catchdining/entity/ReviewComment.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.entity;
 
+import com.jvnlee.catchdining.domain.review.model.Review;
 import com.jvnlee.catchdining.domain.user.model.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,4 +30,5 @@ public class ReviewComment extends BaseEntity {
     private User user;
 
     private String content;
+
 }

--- a/src/test/java/com/jvnlee/catchdining/domain/restaurant/controller/RestaurantControllerTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/restaurant/controller/RestaurantControllerTest.java
@@ -289,7 +289,7 @@ class RestaurantControllerTest {
 
         verify(service).view(Long.valueOf(restaurantId));
         resultActions
-                .andExpect(status().isNotFound())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("식당 정보가 존재하지 않습니다."))
                 .andExpect(jsonPath("$.data").isEmpty());
     }
@@ -370,7 +370,7 @@ class RestaurantControllerTest {
 
         verify(service).delete(Long.valueOf(restaurantId));
         resultActions
-                .andExpect(status().isNotFound())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("식당 정보가 존재하지 않습니다."));
     }
 

--- a/src/test/java/com/jvnlee/catchdining/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/review/controller/ReviewControllerTest.java
@@ -1,0 +1,142 @@
+package com.jvnlee.catchdining.domain.review.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
+import com.jvnlee.catchdining.domain.review.dto.ReviewCreateRequestDto;
+import com.jvnlee.catchdining.domain.review.service.ReviewService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(
+        controllers = {ReviewController.class},
+        excludeAutoConfiguration = SecurityAutoConfiguration.class
+)
+@MockBean(JpaMetamodelMappingContext.class)
+class ReviewControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper om;
+
+    @MockBean
+    ReviewService service;
+
+    @Test
+    @DisplayName("리뷰 생성 성공")
+    void create_success() throws Exception {
+        Long restaurantId = 1L;
+        ReviewCreateRequestDto reviewCreateRequestDto = new ReviewCreateRequestDto(
+                restaurantId,
+                4.0,
+                4.5,
+                5.0,
+                "Love this place!"
+        );
+
+        String requestBody = om.writeValueAsString(reviewCreateRequestDto);
+
+        ResultActions resultActions = mockMvc.perform(
+                post("/restaurants/{restaurantId}/reviews", restaurantId)
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        verify(service).create(any());
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("리뷰 등록 성공"));
+    }
+
+    @Test
+    @DisplayName("리뷰 생성 실패: 존재하지 않는 식당")
+    void create_fail_no_restaurant() throws Exception {
+        Long restaurantId = 1L;
+        ReviewCreateRequestDto reviewCreateRequestDto = new ReviewCreateRequestDto(
+                restaurantId,
+                4.0,
+                4.5,
+                5.0,
+                "Love this place!"
+        );
+
+        String requestBody = om.writeValueAsString(reviewCreateRequestDto);
+
+        doThrow(RestaurantNotFoundException.class).when(service).create(any());
+
+        ResultActions resultActions = mockMvc.perform(
+                post("/restaurants/{restaurantId}/reviews", restaurantId)
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        verify(service).create(any());
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("식당 정보가 존재하지 않습니다."));
+    }
+
+    @Test
+    @DisplayName("특정 유저가 작성한 리뷰 조회")
+    void viewByUser() throws Exception {
+        Long userId = 1L;
+        ResultActions resultActions = mockMvc.perform(
+                get("/users/{userId}/reviews", userId)
+        );
+
+        verify(service).viewByUser(userId);
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("유저가 작성한 리뷰 조회 결과"));
+    }
+
+    @Test
+    @DisplayName("특정 식당에 등록된 리뷰 조회")
+    void viewByRestaurant() throws Exception {
+        Long restaurantId = 1L;
+        ResultActions resultActions = mockMvc.perform(
+                get("/restaurants/{restaurantId}/reviews", restaurantId)
+        );
+
+        verify(service).viewByRestaurant(restaurantId);
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("식당에 등록된 리뷰 조회 결과"));
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 성공")
+    void delete_success() throws Exception {
+        Long userId = 1L;
+        Long reviewId = 1L;
+        ResultActions resultActions = mockMvc.perform(
+                delete("/users/{userId}/reviews/{reviewId}", userId, reviewId)
+        );
+
+        verify(service).delete(reviewId);
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("리뷰 삭제 성공"));
+    }
+
+}

--- a/src/test/java/com/jvnlee/catchdining/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/review/service/ReviewServiceTest.java
@@ -1,0 +1,112 @@
+package com.jvnlee.catchdining.domain.review.service;
+
+import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
+import com.jvnlee.catchdining.domain.reservation.model.Reservation;
+import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
+import com.jvnlee.catchdining.domain.restaurant.repository.RestaurantRepository;
+import com.jvnlee.catchdining.domain.review.dto.ReviewCreateRequestDto;
+import com.jvnlee.catchdining.domain.review.model.Review;
+import com.jvnlee.catchdining.domain.review.repository.ReviewRepository;
+import com.jvnlee.catchdining.domain.user.model.User;
+import com.jvnlee.catchdining.domain.user.service.UserService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @Mock
+    ReviewRepository reviewRepository;
+
+    @Mock
+    RestaurantRepository restaurantRepository;
+
+    @Mock
+    UserService userService;
+
+    @InjectMocks
+    ReviewService reviewService;
+
+    @Test
+    @DisplayName("리뷰 생성 성공")
+    void create_success() {
+        ReviewCreateRequestDto reviewCreateRequestDto = new ReviewCreateRequestDto(
+                1L,
+                4.0,
+                4.5,
+                5.0,
+                "Love this place!"
+        );
+
+        User user = mock(User.class);
+        Restaurant restaurant = mock(Restaurant.class);
+
+        when(userService.getCurrentUser()).thenReturn(user);
+        when(restaurantRepository.findById(anyLong())).thenReturn(Optional.of(restaurant));
+
+        reviewService.create(reviewCreateRequestDto);
+
+        verify(reviewRepository).save(any(Review.class));
+    }
+
+    @Test
+    @DisplayName("리뷰 생성 실패: 존재하지 않는 식당")
+    void create_fail_no_restaurant() {
+        ReviewCreateRequestDto reviewCreateRequestDto = new ReviewCreateRequestDto(
+                1L,
+                4.0,
+                4.5,
+                5.0,
+                "Love this place!"
+        );
+
+        User user = mock(User.class);
+
+        when(userService.getCurrentUser()).thenReturn(user);
+        when(restaurantRepository.findById(anyLong())).thenThrow(RestaurantNotFoundException.class);
+
+        assertThatThrownBy(() -> reviewService.create(reviewCreateRequestDto)).isInstanceOf(RestaurantNotFoundException.class);
+        verify(reviewRepository, times(0)).save(any(Review.class));
+    }
+
+    @Test
+    @DisplayName("특정 유저가 작성한 리뷰 조회")
+    void viewByUser() {
+        Long userId = 1L;
+        reviewService.viewByUser(userId);
+        verify(reviewRepository).findAllByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("특정 식당에 등록된 리뷰 조회")
+    void viewByRestaurant() {
+        Long restaurantId = 1L;
+        reviewService.viewByRestaurant(restaurantId);
+        verify(reviewRepository).findAllByRestaurantId(restaurantId);
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 성공")
+    void delete() {
+        Long reviewId = 1L;
+        reviewService.delete(reviewId);
+        verify(reviewRepository).deleteById(reviewId);
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

사용자가 식당에 대해 남기는 평가인 리뷰를 대변하는 `Review` 엔티티를 중심으로 생성, 조회, 삭제 API 구현

> 모티브인 Catch Table 서비스에는 리뷰 수정 기능이 없음.

&nbsp;

## ReviewRepository

- `findAllByUserId()`: 특정 `userId`를 가진 사용자가 남긴 리뷰 데이터를 `ReviewViewByUserDto` 리스트로 반환

- `findAllByRestaurantId()`: 특정 `restaurantId`를 가진 식당에 등록된 리뷰 데이터를 `ReviewViewByRestaurantDto` 리스트로 반환

&nbsp;

## ReviewService

- `create()`: 사용자가 특정 식당에 대해 선택한 3가지 별점과 평가한 글로 이루어진 리뷰 등록 

- `viewByUser()`: 특정 `userId`를 가진 사용자가 남긴 리뷰 데이터를 `ReviewViewByUserResponseDto` 리스트로 반환

- `viewByRestaurantId()`: 특정 `restaurantId`를 가진 식당에 등록된 리뷰 데이터를 `ReviewViewByRestaurantResponseDto` 리스트로 반환

- `delete()`: 특정 `reviewId`를 가진 리뷰 레코드 제거

&nbsp;

## ReviewController

| Method | Endpoint | Parameters | Authorities | Success | Fail |
| ----- | ----- | ----- | ----- | ----- | ----- |
| POST |/restaurants/{restaurantId}/reviews | - | CUSTOMER, OWNER | 200 | 400 |
| GET | /users/{userId}/reviews | - | CUSTOMER, OWNER | 200 | 400 |
| GET | /restaurants/{restaurantId}/reviews | - | CUSTOMER, OWNER | 200 | 400 |
| DELETE | /users/{userId}/reviews/{reviewId} | - | CUSTOMER, OWNER | 200 | 400 |

&nbsp;

## 테스트

- `ReviewServiceTest`와 `ReviewControllerTest`에서 단위 테스트 진행