### PR TITLE
feature/#48 rabbitmq application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'org.springframework.retry:spring-retry'
 	implementation 'org.springframework:spring-aspects'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	implementation 'com.rabbitmq:amqp-client:5.21.0'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
 			'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 	implementation 'org.springframework:spring-aspects'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
-	implementation 'com.rabbitmq:amqp-client:5.21.0'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
 			'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.testcontainers:testcontainers:1.19.8'
 	testImplementation 'org.testcontainers:mysql:1.19.8'
+	testImplementation 'org.testcontainers:rabbitmq:1.19.8'
 	testImplementation ('io.rest-assured:rest-assured:5.4.0') {
 		exclude group: 'org.apache.groovy', module: 'groovy'
 		exclude group: 'org.apache.groovy', module: 'groovy-xml'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -67,6 +67,15 @@ services:
     networks:
       - catch-dining-net
 
+  rabbitmq:
+    container_name: rabbitmq
+    image: rabbitmq:3.13.6
+    ports:
+      - "5672:5672"
+    restart: always
+    networks:
+      - catch-dining-net
+
 networks:
   catch-dining-net:
     driver: bridge

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -67,6 +67,15 @@ services:
     networks:
       - catch-dining-net
 
+  rabbitmq:
+    container_name: rabbitmq
+    image: rabbitmq:3.13.6
+    ports:
+      - "5672:5672"
+    restart: always
+    networks:
+      - catch-dining-net
+
 networks:
   catch-dining-net:
     driver: bridge

--- a/init-write-db.sql
+++ b/init-write-db.sql
@@ -21,27 +21,6 @@ CREATE TABLE IF NOT EXISTS restaurant
     serving_type       VARCHAR(255)
 );
 
-CREATE TABLE IF NOT EXISTS restaurant_review_stat
-(
-    restaurant_review_stat_id BIGINT PRIMARY KEY,
-    created_date              DATETIME(6) NOT NULL,
-    last_modified_date        DATETIME(6) NOT NULL,
-    name                      VARCHAR(255) UNIQUE,
-    city                      VARCHAR(255),
-    detail                    VARCHAR(255),
-    district                  VARCHAR(255),
-    province                  VARCHAR(255),
-    street                    VARCHAR(255),
-    phone_number              VARCHAR(20),
-    description               VARCHAR(255),
-    avg_rating                DOUBLE,
-    review_count              INT,
-    country_type              VARCHAR(255),
-    food_type                 VARCHAR(255),
-    serving_type              VARCHAR(255),
-    version                   INT
-);
-
 CREATE TABLE IF NOT EXISTS `user`
 (
     user_id            BIGINT AUTO_INCREMENT PRIMARY KEY,

--- a/src/main/java/com/jvnlee/catchdining/common/annotation/RabbitManualAck.java
+++ b/src/main/java/com/jvnlee/catchdining/common/annotation/RabbitManualAck.java
@@ -1,0 +1,11 @@
+package com.jvnlee.catchdining.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RabbitManualAck {
+}

--- a/src/main/java/com/jvnlee/catchdining/common/aspect/RabbitManualAckAspect.java
+++ b/src/main/java/com/jvnlee/catchdining/common/aspect/RabbitManualAckAspect.java
@@ -1,0 +1,35 @@
+package com.jvnlee.catchdining.common.aspect;
+
+import com.jvnlee.catchdining.common.annotation.RabbitManualAck;
+import com.rabbitmq.client.Channel;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Aspect
+@Component
+public class RabbitManualAckAspect {
+
+    @Around("@annotation(rabbitManualAck)")
+    public void applyManualAck(ProceedingJoinPoint joinPoint, RabbitManualAck rabbitManualAck) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+        Object event = args[0];
+        Channel channel = (Channel) args[1];
+        long tag = (Long) args[2];
+
+        try {
+            joinPoint.proceed();
+            channel.basicAck(tag, false);
+            log.info("이벤트 처리 완료: {}", event);
+        } catch (IOException e) {
+            channel.basicNack(tag, false, true);
+            log.error("이벤트 처리 실패: {}", event);
+        }
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/common/config/RabbitMQConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/RabbitMQConfig.java
@@ -1,0 +1,57 @@
+package com.jvnlee.catchdining.common.config;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    @Value("${spring.rabbitmq.host}")
+    private String host;
+
+    @Value("${spring.rabbitmq.port}")
+    private int port;
+
+    @Value("${spring.rabbitmq.username}")
+    private String username;
+
+    @Value("${spring.rabbitmq.password}")
+    private String password;
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory(host, port);
+        connectionFactory.setUsername(username);
+        connectionFactory.setPassword(password);
+        return connectionFactory;
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(new Jackson2JsonMessageConverter());
+        return rabbitTemplate;
+    }
+
+    @Bean
+    public Jackson2JsonMessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public Queue reviewEventQueue() {
+        return new Queue("reviewEventQueue");
+    }
+
+    @Bean
+    public Queue restaurantEventQueue() {
+        return new Queue("restaurantEventQueue");
+    }
+
+}

--- a/src/main/java/com/jvnlee/catchdining/common/config/RabbitMQConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/RabbitMQConfig.java
@@ -24,6 +24,10 @@ public class RabbitMQConfig {
     @Value("${spring.rabbitmq.password}")
     private String password;
 
+    public static final String REVIEW_EVENT_QUEUE = "REVIEW_EVENT_QUEUE";
+
+    public static final String RESTAURANT_EVENT_QUEUE = "RESTAURANT_EVENT_QUEUE";
+
     @Bean
     public ConnectionFactory connectionFactory() {
         CachingConnectionFactory connectionFactory = new CachingConnectionFactory(host, port);
@@ -46,12 +50,12 @@ public class RabbitMQConfig {
 
     @Bean
     public Queue reviewEventQueue() {
-        return new Queue("reviewEventQueue");
+        return new Queue(REVIEW_EVENT_QUEUE);
     }
 
     @Bean
     public Queue restaurantEventQueue() {
-        return new Queue("restaurantEventQueue");
+        return new Queue(RESTAURANT_EVENT_QUEUE);
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantCreatedEvent.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantCreatedEvent.java
@@ -3,8 +3,10 @@ package com.jvnlee.catchdining.domain.restaurant.event;
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class RestaurantCreatedEvent {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantDeletedEvent.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantDeletedEvent.java
@@ -2,8 +2,10 @@ package com.jvnlee.catchdining.domain.restaurant.event;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class RestaurantDeletedEvent {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantEventHandler.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantEventHandler.java
@@ -7,9 +7,10 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import static com.jvnlee.catchdining.common.config.RabbitMQConfig.RESTAURANT_EVENT_QUEUE;
 @Component
 @RequiredArgsConstructor
-@RabbitListener(queues = "restaurantEventQueue")
+@RabbitListener(queues = RESTAURANT_EVENT_QUEUE)
 public class RestaurantEventHandler {
 
     private final RestaurantReviewStatService restaurantReviewStatService;

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantEventHandler.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantEventHandler.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.domain.restaurant.event;
 
+import com.jvnlee.catchdining.common.annotation.RabbitManualAck;
 import com.jvnlee.catchdining.domain.restaurant.service.RestaurantReviewStatService;
 import com.rabbitmq.client.Channel;
 import lombok.RequiredArgsConstructor;
@@ -26,44 +27,20 @@ public class RestaurantEventHandler {
     @Async
     @RabbitHandler
     public void handleCreated(RestaurantCreatedEvent event, Channel channel, @Header(DELIVERY_TAG) long tag) throws IOException {
-        try {
-            restaurantReviewStatService.register(event.getRestaurantId(), event.getRestaurantDto());
-
-            channel.basicAck(tag, false);
-            log.info("이벤트 처리 완료: {}", event);
-        } catch (IOException e) {
-            channel.basicNack(tag, false, true);
-            log.error("이벤트 처리 실패: {}", event);
-        }
+        restaurantReviewStatService.register(event.getRestaurantId(), event.getRestaurantDto());
     }
 
     @Async
     @RabbitHandler
+    @RabbitManualAck
     public void handleUpdated(RestaurantUpdatedEvent event, Channel channel, @Header(DELIVERY_TAG) long tag) throws IOException {
-        try {
-            restaurantReviewStatService.update(event.getRestaurantId(), event.getRestaurantDto());
-
-            channel.basicAck(tag, false);
-            log.info("이벤트 처리 완료: {}", event);
-        } catch (IOException e) {
-            channel.basicNack(tag, false, true);
-            log.error("이벤트 처리 실패: {}", event);
-        }
-
+        restaurantReviewStatService.update(event.getRestaurantId(), event.getRestaurantDto());
     }
 
     @Async
     @RabbitHandler
     public void handleDeleted(RestaurantDeletedEvent event, Channel channel, @Header(DELIVERY_TAG) long tag) throws IOException {
-        try {
-            restaurantReviewStatService.delete(event.getRestaurantId());
-
-            channel.basicAck(tag, false);
-            log.info("이벤트 처리 완료: {}", event);
-        } catch (IOException e) {
-            channel.basicNack(tag, false, true);
-            log.error("이벤트 처리 실패: {}", event);
-        }
+        restaurantReviewStatService.delete(event.getRestaurantId());
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantEventHandler.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantEventHandler.java
@@ -1,13 +1,21 @@
 package com.jvnlee.catchdining.domain.restaurant.event;
 
 import com.jvnlee.catchdining.domain.restaurant.service.RestaurantReviewStatService;
+import com.rabbitmq.client.Channel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
+
 import static com.jvnlee.catchdining.common.config.RabbitMQConfig.RESTAURANT_EVENT_QUEUE;
+import static org.springframework.amqp.support.AmqpHeaders.DELIVERY_TAG;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 @RabbitListener(queues = RESTAURANT_EVENT_QUEUE)
@@ -17,20 +25,45 @@ public class RestaurantEventHandler {
 
     @Async
     @RabbitHandler
-    public void handleCreated(RestaurantCreatedEvent event) {
-        restaurantReviewStatService.register(event.getRestaurantId(), event.getRestaurantDto());
+    public void handleCreated(RestaurantCreatedEvent event, Channel channel, @Header(DELIVERY_TAG) long tag) throws IOException {
+        try {
+            restaurantReviewStatService.register(event.getRestaurantId(), event.getRestaurantDto());
+
+            channel.basicAck(tag, false);
+            log.info("이벤트 처리 완료: {}", event);
+        } catch (IOException e) {
+            channel.basicNack(tag, false, true);
+            log.error("이벤트 처리 실패: {}", event);
+        }
     }
 
     @Async
     @RabbitHandler
-    public void handleUpdated(RestaurantUpdatedEvent event) {
-        restaurantReviewStatService.update(event.getRestaurantId(), event.getRestaurantDto());
+    public void handleUpdated(RestaurantUpdatedEvent event, Channel channel, @Header(DELIVERY_TAG) long tag) throws IOException {
+        try {
+            restaurantReviewStatService.update(event.getRestaurantId(), event.getRestaurantDto());
+
+            channel.basicAck(tag, false);
+            log.info("이벤트 처리 완료: {}", event);
+        } catch (IOException e) {
+            channel.basicNack(tag, false, true);
+            log.error("이벤트 처리 실패: {}", event);
+        }
+
     }
 
     @Async
     @RabbitHandler
-    public void handleDeleted(RestaurantDeletedEvent event) {
-        restaurantReviewStatService.delete(event.getRestaurantId());
+    public void handleDeleted(RestaurantDeletedEvent event, Channel channel, @Header(DELIVERY_TAG) long tag) throws IOException {
+        try {
+            restaurantReviewStatService.delete(event.getRestaurantId());
+
+            channel.basicAck(tag, false);
+            log.info("이벤트 처리 완료: {}", event);
+        } catch (IOException e) {
+            channel.basicNack(tag, false, true);
+            log.error("이벤트 처리 실패: {}", event);
+        }
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantEventHandler.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantEventHandler.java
@@ -2,30 +2,32 @@ package com.jvnlee.catchdining.domain.restaurant.event;
 
 import com.jvnlee.catchdining.domain.restaurant.service.RestaurantReviewStatService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.annotation.RabbitHandler;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
+@RabbitListener(queues = "restaurantEventQueue")
 public class RestaurantEventHandler {
 
     private final RestaurantReviewStatService restaurantReviewStatService;
 
     @Async
-    @TransactionalEventListener
+    @RabbitHandler
     public void handleCreated(RestaurantCreatedEvent event) {
         restaurantReviewStatService.register(event.getRestaurantId(), event.getRestaurantDto());
     }
 
     @Async
-    @TransactionalEventListener
+    @RabbitHandler
     public void handleUpdated(RestaurantUpdatedEvent event) {
         restaurantReviewStatService.update(event.getRestaurantId(), event.getRestaurantDto());
     }
 
     @Async
-    @TransactionalEventListener
+    @RabbitHandler
     public void handleDeleted(RestaurantDeletedEvent event) {
         restaurantReviewStatService.delete(event.getRestaurantId());
     }

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantUpdatedEvent.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/event/RestaurantUpdatedEvent.java
@@ -3,8 +3,10 @@ package com.jvnlee.catchdining.domain.restaurant.event;
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class RestaurantUpdatedEvent {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/service/RestaurantReviewStatService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/service/RestaurantReviewStatService.java
@@ -20,16 +20,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.OptimisticLockException;
 
-import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
-
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class RestaurantReviewStatService {
 
     private final RestaurantReviewStatRepository restaurantReviewStatRepository;
 
     @AggregatedData
-    @Transactional(propagation = REQUIRES_NEW)
     public void register(Long id, RestaurantDto restaurantDto) {
         restaurantReviewStatRepository.save(new RestaurantReviewStat(id, restaurantDto));
     }
@@ -69,7 +67,6 @@ public class RestaurantReviewStatService {
             maxAttempts = 10
     )
     @AggregatedData
-    @Transactional(propagation = REQUIRES_NEW)
     public void updateReviewData(Long restaurantId, double tasteRating, double moodRating, double serviceRating) {
         RestaurantReviewStat restaurantReviewStat = restaurantReviewStatRepository
                 .findById(restaurantId)
@@ -79,7 +76,6 @@ public class RestaurantReviewStatService {
     }
 
     @AggregatedData
-    @Transactional(propagation = REQUIRES_NEW)
     public void update(Long restaurantId, RestaurantDto restaurantDto) {
         RestaurantReviewStat restaurantReviewStat = restaurantReviewStatRepository
                 .findById(restaurantId)
@@ -89,7 +85,6 @@ public class RestaurantReviewStatService {
     }
 
     @AggregatedData
-    @Transactional(propagation = REQUIRES_NEW)
     public void delete(Long restaurantId) {
         restaurantReviewStatRepository.deleteById(restaurantId);
     }

--- a/src/main/java/com/jvnlee/catchdining/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/restaurant/service/RestaurantService.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.domain.restaurant.service;
 
+import com.jvnlee.catchdining.common.config.RabbitMQConfig;
 import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantCreateResponseDto;
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantDto;
@@ -16,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+import static com.jvnlee.catchdining.common.config.RabbitMQConfig.RESTAURANT_EVENT_QUEUE;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -29,7 +32,7 @@ public class RestaurantService {
         validateName(restaurantDto.getName());
         Restaurant restaurant = new Restaurant(restaurantDto);
         Restaurant saved = restaurantRepository.save(restaurant);
-        rabbitTemplate.convertAndSend("restaurantEventQueue", new RestaurantCreatedEvent(restaurant.getId(), restaurantDto));
+        rabbitTemplate.convertAndSend(RESTAURANT_EVENT_QUEUE, new RestaurantCreatedEvent(restaurant.getId(), restaurantDto));
         return new RestaurantCreateResponseDto(saved.getId());
     }
 
@@ -39,12 +42,12 @@ public class RestaurantService {
                 .findById(id)
                 .orElseThrow(RestaurantNotFoundException::new);
         restaurant.update(restaurantUpdateDto);
-        rabbitTemplate.convertAndSend("restaurantEventQueue", new RestaurantUpdatedEvent(id, restaurantUpdateDto));
+        rabbitTemplate.convertAndSend(RESTAURANT_EVENT_QUEUE, new RestaurantUpdatedEvent(id, restaurantUpdateDto));
     }
 
     public void delete(Long id) {
         restaurantRepository.deleteById(id);
-        rabbitTemplate.convertAndSend("restaurantEventQueue", new RestaurantDeletedEvent(id));
+        rabbitTemplate.convertAndSend(RESTAURANT_EVENT_QUEUE, new RestaurantDeletedEvent(id));
     }
 
     private void validateName(String name) {

--- a/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewCreatedEvent.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewCreatedEvent.java
@@ -2,8 +2,10 @@ package com.jvnlee.catchdining.domain.review.event;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ReviewCreatedEvent {
 

--- a/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewCreatedEventHandler.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewCreatedEventHandler.java
@@ -2,9 +2,9 @@ package com.jvnlee.catchdining.domain.review.event;
 
 import com.jvnlee.catchdining.domain.restaurant.service.RestaurantReviewStatService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -13,7 +13,7 @@ public class ReviewCreatedEventHandler {
     private final RestaurantReviewStatService restaurantReviewStatService;
 
     @Async
-    @TransactionalEventListener
+    @RabbitListener(queues = "reviewEventQueue")
     public void handle(ReviewCreatedEvent event) {
         restaurantReviewStatService.updateReviewData(
                 event.getRestaurantId(),

--- a/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewEventHandler.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewEventHandler.java
@@ -10,7 +10,7 @@ import static com.jvnlee.catchdining.common.config.RabbitMQConfig.REVIEW_EVENT_Q
 
 @Component
 @RequiredArgsConstructor
-public class ReviewCreatedEventHandler {
+public class ReviewEventHandler {
 
     private final RestaurantReviewStatService restaurantReviewStatService;
 

--- a/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewEventHandler.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewEventHandler.java
@@ -1,13 +1,20 @@
 package com.jvnlee.catchdining.domain.review.event;
 
 import com.jvnlee.catchdining.domain.restaurant.service.RestaurantReviewStatService;
+import com.rabbitmq.client.Channel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
-import static com.jvnlee.catchdining.common.config.RabbitMQConfig.REVIEW_EVENT_QUEUE;
+import java.io.IOException;
 
+import static com.jvnlee.catchdining.common.config.RabbitMQConfig.REVIEW_EVENT_QUEUE;
+import static org.springframework.amqp.support.AmqpHeaders.DELIVERY_TAG;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReviewEventHandler {
@@ -16,13 +23,21 @@ public class ReviewEventHandler {
 
     @Async
     @RabbitListener(queues = REVIEW_EVENT_QUEUE)
-    public void handleCreated(ReviewCreatedEvent event) {
-        restaurantReviewStatService.updateReviewData(
-                event.getRestaurantId(),
-                event.getTasteRating(),
-                event.getMoodRating(),
-                event.getServiceRating()
-        );
+    public void handleCreated(ReviewCreatedEvent event, Channel channel, @Header(DELIVERY_TAG) long tag) throws IOException {
+        try {
+            restaurantReviewStatService.updateReviewData(
+                    event.getRestaurantId(),
+                    event.getTasteRating(),
+                    event.getMoodRating(),
+                    event.getServiceRating()
+            );
+
+            channel.basicAck(tag, false);
+            log.info("이벤트 처리 완료: {}", event);
+        } catch (IOException e) {
+            channel.basicNack(tag, false, true);
+            log.error("이벤트 처리 실패: {}", event);
+        }
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewEventHandler.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewEventHandler.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.domain.review.event;
 
+import com.jvnlee.catchdining.common.annotation.RabbitManualAck;
 import com.jvnlee.catchdining.domain.restaurant.service.RestaurantReviewStatService;
 import com.rabbitmq.client.Channel;
 import lombok.RequiredArgsConstructor;
@@ -23,21 +24,14 @@ public class ReviewEventHandler {
 
     @Async
     @RabbitListener(queues = REVIEW_EVENT_QUEUE)
+    @RabbitManualAck
     public void handleCreated(ReviewCreatedEvent event, Channel channel, @Header(DELIVERY_TAG) long tag) throws IOException {
-        try {
-            restaurantReviewStatService.updateReviewData(
-                    event.getRestaurantId(),
-                    event.getTasteRating(),
-                    event.getMoodRating(),
-                    event.getServiceRating()
-            );
-
-            channel.basicAck(tag, false);
-            log.info("이벤트 처리 완료: {}", event);
-        } catch (IOException e) {
-            channel.basicNack(tag, false, true);
-            log.error("이벤트 처리 실패: {}", event);
-        }
+        restaurantReviewStatService.updateReviewData(
+                event.getRestaurantId(),
+                event.getTasteRating(),
+                event.getMoodRating(),
+                event.getServiceRating()
+        );
     }
 
 }

--- a/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewEventHandler.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/event/ReviewEventHandler.java
@@ -6,6 +6,8 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import static com.jvnlee.catchdining.common.config.RabbitMQConfig.REVIEW_EVENT_QUEUE;
+
 @Component
 @RequiredArgsConstructor
 public class ReviewCreatedEventHandler {
@@ -13,8 +15,8 @@ public class ReviewCreatedEventHandler {
     private final RestaurantReviewStatService restaurantReviewStatService;
 
     @Async
-    @RabbitListener(queues = "reviewEventQueue")
-    public void handle(ReviewCreatedEvent event) {
+    @RabbitListener(queues = REVIEW_EVENT_QUEUE)
+    public void handleCreated(ReviewCreatedEvent event) {
         restaurantReviewStatService.updateReviewData(
                 event.getRestaurantId(),
                 event.getTasteRating(),

--- a/src/main/java/com/jvnlee/catchdining/domain/review/service/ReviewService.java
+++ b/src/main/java/com/jvnlee/catchdining/domain/review/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.jvnlee.catchdining.domain.review.service;
 
+import com.jvnlee.catchdining.common.config.RabbitMQConfig;
 import com.jvnlee.catchdining.common.exception.RestaurantNotFoundException;
 import com.jvnlee.catchdining.domain.restaurant.model.Restaurant;
 import com.jvnlee.catchdining.domain.restaurant.repository.RestaurantRepository;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.jvnlee.catchdining.common.config.RabbitMQConfig.REVIEW_EVENT_QUEUE;
 import static java.util.stream.Collectors.*;
 
 @Service
@@ -62,7 +64,7 @@ public class ReviewService {
                 serviceRating
         );
 
-        rabbitTemplate.convertAndSend("reviewEventQueue", reviewCreatedEvent);
+        rabbitTemplate.convertAndSend(REVIEW_EVENT_QUEUE, reviewCreatedEvent);
     }
 
     public List<ReviewViewByUserResponseDto> viewByUser(Long userId) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,6 +19,9 @@ spring:
     port: 5672
     username: guest
     password: guest
+    listener:
+      simple:
+        acknowledge-mode: manual
 
 logging:
   level:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,6 +14,12 @@ spring:
     host: redis
     port: 6379
 
+  rabbitmq:
+    host: rabbitmq
+    port: 5672
+    username: guest
+    password: guest
+
 logging:
   level:
     org:

--- a/src/test/java/com/jvnlee/catchdining/domain/restaurant/service/RestaurantServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/restaurant/service/RestaurantServiceTest.java
@@ -1,6 +1,5 @@
 package com.jvnlee.catchdining.domain.restaurant.service;
 
-import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantCreateResponseDto;
 import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantDto;
 import com.jvnlee.catchdining.domain.restaurant.event.RestaurantCreatedEvent;
 import com.jvnlee.catchdining.domain.restaurant.event.RestaurantDeletedEvent;
@@ -14,7 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.dao.DuplicateKeyException;
 
 import java.util.Optional;
@@ -33,7 +32,7 @@ class RestaurantServiceTest {
     RestaurantRepository repository;
 
     @Mock
-    ApplicationEventPublisher eventPublisher;
+    RabbitTemplate rabbitTemplate;
 
     @InjectMocks
     RestaurantService service;
@@ -51,7 +50,7 @@ class RestaurantServiceTest {
         service.register(restaurantDto);
 
         verify(repository).save(any(Restaurant.class));
-        verify(eventPublisher).publishEvent(any(RestaurantCreatedEvent.class));
+        verify(rabbitTemplate).convertAndSend(anyString(), any(RestaurantCreatedEvent.class));
     }
 
     @Test
@@ -82,7 +81,7 @@ class RestaurantServiceTest {
         service.update(restaurantId, restaurantDto);
 
         verify(restaurant).update(restaurantDto);
-        verify(eventPublisher).publishEvent(any(RestaurantUpdatedEvent.class));
+        verify(rabbitTemplate).convertAndSend(anyString(), any(RestaurantUpdatedEvent.class));
     }
 
     @Test
@@ -110,7 +109,7 @@ class RestaurantServiceTest {
         service.delete(restaurantId);
 
         verify(repository).deleteById(restaurantId);
-        verify(eventPublisher).publishEvent(any(RestaurantDeletedEvent.class));
+        verify(rabbitTemplate).convertAndSend(anyString(), any(RestaurantDeletedEvent.class));
     }
 
 }

--- a/src/test/java/com/jvnlee/catchdining/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/domain/review/service/ReviewServiceTest.java
@@ -15,13 +15,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -40,7 +41,7 @@ class ReviewServiceTest {
     UserService userService;
 
     @Mock
-    ApplicationEventPublisher eventPublisher;
+    RabbitTemplate rabbitTemplate;
 
     @InjectMocks
     ReviewService reviewService;
@@ -65,7 +66,7 @@ class ReviewServiceTest {
         reviewService.create(reviewCreateRequestDto);
 
         verify(reviewRepository).save(any(Review.class));
-        verify(eventPublisher).publishEvent(any(ReviewCreatedEvent.class));
+        verify(rabbitTemplate).convertAndSend(anyString(), any(ReviewCreatedEvent.class));
     }
 
     @Test

--- a/src/test/java/com/jvnlee/catchdining/integration/ReservationIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/ReservationIntegrationTest.java
@@ -104,7 +104,7 @@ class ReservationIntegrationTest extends TestcontainersContext {
 
         RestAssured
                 .given().log().all()
-                .pathParam("restaurantId", 1L)
+                .pathParam("restaurantId", restaurantId)
                 .header(AUTHORIZATION, authHeader)
                 .body(seatAddRequestBody)
                 .contentType(JSON)

--- a/src/test/java/com/jvnlee/catchdining/integration/RestaurantReviewStatIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/RestaurantReviewStatIntegrationTest.java
@@ -83,6 +83,8 @@ public class RestaurantReviewStatIntegrationTest extends TestcontainersContext {
 
         Long restaurantId = ((Integer) response.path("data.restaurantId")).longValue();
 
+        Thread.sleep(1000);
+
         // READ-DB에서 조회하여 RestaurantReviewStat 생성 확인
         RestAssured
                 .given().log().all()
@@ -127,6 +129,8 @@ public class RestaurantReviewStatIntegrationTest extends TestcontainersContext {
                 .when()
                 .post("/restaurants/{restaurantId}/reviews")
                 .then().log().all();
+
+        Thread.sleep(1000);
 
         // READ-DB에서 조회하여 RestaurantReviewStat 업데이트 반영 확인
         RestAssured
@@ -175,6 +179,8 @@ public class RestaurantReviewStatIntegrationTest extends TestcontainersContext {
                 .put("/restaurants/{restaurantId}")
                 .then().log().all();
 
+        Thread.sleep(1000);
+
         // READ-DB에서 조회하여 RestaurantReviewStat 업데이트 반영 확인
         RestAssured
                 .given().log().all()
@@ -214,6 +220,8 @@ public class RestaurantReviewStatIntegrationTest extends TestcontainersContext {
                 .when()
                 .delete("/restaurants/{restaurantId}")
                 .then().log().all();
+
+        Thread.sleep(1000);
 
         // READ-DB에서 조회하여 RestaurantReviewStat 삭제 반영 확인
         RestAssured

--- a/src/test/java/com/jvnlee/catchdining/integration/TestcontainersContext.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/TestcontainersContext.java
@@ -5,6 +5,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.RabbitMQContainer;
 
 public class TestcontainersContext {
 
@@ -19,6 +20,10 @@ public class TestcontainersContext {
     private static final GenericContainer<?> REDIS;
     private static final int REDIS_PORT = 6379;
 
+    private static final String RABBITMQ_IMAGE = "rabbitmq:3.13.6";
+    private static final RabbitMQContainer RABBITMQ;
+    private static final int RABBITMQ_PORT = 5672;
+
     static {
         WRITE_DB = new MySQLContainer<>(MYSQL_IMAGE)
                 .withDatabaseName(DATABASE_NAME)
@@ -28,10 +33,13 @@ public class TestcontainersContext {
                 .withInitScript(READ_DB_INIT_SCRIPT_NAME);
         REDIS = new GenericContainer<>(REDIS_IMAGE)
                 .withExposedPorts(REDIS_PORT);
+        RABBITMQ = new RabbitMQContainer(RABBITMQ_IMAGE)
+                .withExposedPorts(RABBITMQ_PORT);
 
         WRITE_DB.start();
         READ_DB.start();
         REDIS.start();
+        RABBITMQ.start();
     }
 
     @DynamicPropertySource
@@ -48,6 +56,11 @@ public class TestcontainersContext {
 
         registry.add("spring.redis.host", REDIS::getHost);
         registry.add("spring.redis.port", () -> REDIS.getMappedPort(REDIS_PORT).toString());
+
+        registry.add("spring.rabbitmq.host", RABBITMQ::getHost);
+        registry.add("spring.rabbitmq.port", () -> RABBITMQ.getMappedPort(RABBITMQ_PORT).toString());
+        registry.add("spring.rabbitmq.username", RABBITMQ::getAdminUsername);
+        registry.add("spring.rabbitmq.password", RABBITMQ::getAdminPassword);
     }
 
 }


### PR DESCRIPTION
## 구현 내용

### 🐰 RabbitMQ 도입

메시지 브로커로 사용할 수 있는 Redis, RabbitMQ, Kafka 3가지를 비교해보고 현재 니즈와 서버 환경에 가장 알맞은 RabbitMQ를 선택함.

🔗  [선택 과정 기록](https://jvnlee.vercel.app/message-broker-tools)

🔗  [적용 과정 기록](https://jvnlee.vercel.app/rabbitmq-application)

&nbsp;

### ⚙️ RabbitMQConfig

- `connectionFactory()`: RabbitMQ 연결에 필요한 프로퍼티를 불러와 `ConnectionFactory` Bean 생성

- `rabbitTemplate()`: RabbitMQ 클라이언트와 서버가 메시지를 주고 받을 때 사용할 `RabbitTemplate` Bean 생성

    - `RabbitTemplate`은 클라이언트가 Exchange 또는 Queue로 메시지를 보내고, Queue로부터 메시지를 받아오는 과정을 추상화하여 편의 메서드로 제공함.

    - `Jackson2JsonMessageConverter`를 사용하도록 지정해서 커스텀 Event 객체를 직렬화/역직렬화할 수 있도록 했음
    
    > 따로 설정하지 않으면 `SimpleMessageConverter`를 사용하는데, 문자열, byte[], `Serializable`을 구현한 객체만 다룰 수 있음

- `reviewEventQueue()`: Review 관련 이벤트를 담을 큐를 Bean으로 생성

- `restaurantEventQueue()`: Restaurant 관련 이벤트를 담을 큐를 Bean으로 생성

&nbsp;

### 📌 RabbitTemplate을 이용한 이벤트 발행

기존에 `ApplicationEventPublisher`를 사용하던 코드를 `RabbitTemplate`을 사용하도록 변경함

`RabbitTemplate`은 2개의 파라미터를 갖는 `convertAndSend()` 메서드를 사용해서 이벤트를 발행함

- routingKey: 메시지가 들어갈 목적지 Queue의 식별자

- 메시지(Event 객체)

&nbsp;

### 📌 RabbitListener를 이용한 이벤트 수신

기존에 `@TransactionalEventListener`를 사용하던 코드를 `@RabbitListener`를 사용하도록 변경함

`ReviewEventHandler`의 경우, 현재 이벤트가 한 종류라서 `handle()` 메서드에 `@RabbitListener`를 사용해서 메시지를 받아올 큐를 명시해주었으나, `RestaurantEventHandler`의 경우 이벤트가 세 종류라서 적용법을 달리함.

`RestaurantEventHandler`는 클래스 레벨에 `@RabbitListener`를 붙여 메시지를 받아올 큐를 명시한 다음, 각 핸들러 메서드에 `@RabbitHandler`를 붙여주어 큐에서 온 이벤트 객체의 타입에 맞는 핸들러가 호출되도록 함.

> 하나의 큐에 다양한 타입의 메시지가 혼재되어있을 때 유연한 처리 가능.

Acknowledgment Mode를 `MANUAL`로 설정하여 메시지 처리 후 수동으로 ack 신호를 보낼 수 있게 함

핸들러 메서드에서 `basicAck()`과 `basicNack()`을 사용해서 각각 메시지 처리에 성공한 경우와 실패한 경우 RabbitMQ측으로 ack 또는 n-ack 신호를 보내도록 함. RabbitMQ에서는 ack 처리된 메시지는 큐에서 제거하고, n-ack 처리된 메시지는 requeue 하므로 메시지 처리의 안정성을 높일 수 있음.

&nbsp;

### 📌 @RabbitManualAck과 RabbitManualAckAspect를 이용한 ack 처리와 로깅 로직 관심사 분리

ack 또는 n-ack 신호를 보내고, 해당 이벤트에 대한 로그를 남기는 로직이 모든 이벤트 핸들러 메서드에서 공통적으로 나타나고 있었음. 코드 반복을 줄이기 위해 공통 로직을 별도의 관심사로 분리하기로 결정함. 해당 로직을 적용할 곳을 지정하기 위해 `@RabbitManualAck`이라는 커스텀 어노테이션을 생성하고, AspectJ의 `@Around`를 이용해 공통 로직을 적용하는 `applyManualAck()` 메서드를 생성함. 이벤트 핸들러 메서드에 ack 처리, 로깅과 같은 기능을 그대로 유지하면서도 핵심 로직만 남겨두어 코드 가독성과 유지보수성이 향상됨.

&nbsp;

### 📌 RabbitMQ 컨테이너 추가

로컬과 배포 환경에서 사용하는 Docker Compose YML에 RabbitMQ 컨테이너를 추가함

테스트 환경에서 사용하는 `TestcontainersContext`에 RabbitMQ 컨테이너를 추가함
