### PR TITLE
bug/#60 event object serialization issue handling

### DIFF
--- a/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
+++ b/src/main/java/com/jvnlee/catchdining/common/advice/ControllerAdvice.java
@@ -2,6 +2,7 @@ package com.jvnlee.catchdining.common.advice;
 
 import com.jvnlee.catchdining.common.exception.*;
 import com.jvnlee.catchdining.common.web.Response;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import static org.springframework.http.HttpStatus.*;
 
+@Slf4j
 @RestControllerAdvice
 public class ControllerAdvice {
 
@@ -80,7 +82,8 @@ public class ControllerAdvice {
 
     @ExceptionHandler(RuntimeException.class)
     @ResponseStatus(INTERNAL_SERVER_ERROR)
-    public Response<Void> handleRuntimeException() {
+    public Response<Void> handleRuntimeException(RuntimeException e) {
+        log.error("런타임 예외 발생: ", e);
         return new Response<>("요청 처리 도중 문제가 발생했습니다.");
     }
 

--- a/src/main/java/com/jvnlee/catchdining/common/config/RabbitMQConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/RabbitMQConfig.java
@@ -1,5 +1,8 @@
 package com.jvnlee.catchdining.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -10,6 +13,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class RabbitMQConfig {
 
     @Value("${spring.rabbitmq.host}")
@@ -23,6 +27,8 @@ public class RabbitMQConfig {
 
     @Value("${spring.rabbitmq.password}")
     private String password;
+
+    private final ObjectMapper om;
 
     public static final String REVIEW_EVENT_QUEUE = "REVIEW_EVENT_QUEUE";
 
@@ -39,13 +45,14 @@ public class RabbitMQConfig {
     @Bean
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
-        rabbitTemplate.setMessageConverter(new Jackson2JsonMessageConverter());
+        rabbitTemplate.setMessageConverter(jsonMessageConverter());
         return rabbitTemplate;
     }
 
     @Bean
     public Jackson2JsonMessageConverter jsonMessageConverter() {
-        return new Jackson2JsonMessageConverter();
+        om.findAndRegisterModules();
+        return new Jackson2JsonMessageConverter(om);
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,0 @@
-spring:
-  profiles:
-    active: dev

--- a/src/test/java/com/jvnlee/catchdining/integration/ReservationCancelTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/ReservationCancelTest.java
@@ -1,0 +1,312 @@
+package com.jvnlee.catchdining.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.jvnlee.catchdining.domain.notification.dto.NotificationRequestDto;
+import com.jvnlee.catchdining.domain.notification.model.DiningPeriod;
+import com.jvnlee.catchdining.domain.payment.dto.ReserveMenuDto;
+import com.jvnlee.catchdining.domain.payment.model.PaymentType;
+import com.jvnlee.catchdining.domain.reservation.dto.ReservationRequestDto;
+import com.jvnlee.catchdining.domain.reservation.dto.TmpReservationRequestDto;
+import com.jvnlee.catchdining.domain.reservation.model.ReservationStatus;
+import com.jvnlee.catchdining.domain.restaurant.dto.RestaurantDto;
+import com.jvnlee.catchdining.domain.seat.dto.SeatDto;
+import com.jvnlee.catchdining.domain.seat.model.SeatType;
+import com.jvnlee.catchdining.domain.user.dto.UserDto;
+import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static com.jvnlee.catchdining.common.constant.RedisConstants.SEAT_AVAIL_QTY_PREFIX;
+import static com.jvnlee.catchdining.common.constant.RedisConstants.TMP_RSV_SEAT_ID_PREFIX;
+import static com.jvnlee.catchdining.domain.user.model.UserType.OWNER;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+public class ReservationCancelTest extends TestcontainersContext {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    ObjectMapper om;
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+    @MockBean
+    FirebaseMessaging firebaseMessaging;
+
+    @BeforeEach
+    void beforeEach() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("임시 예약 취소")
+    void cancelTmp() throws Exception {
+        UserDto userJoinDto = new UserDto("andy", "12345", "01012345678", OWNER);
+        String userJoinRequestBody = om.writeValueAsString(userJoinDto);
+
+        RestAssured
+                .given().log().all()
+                .body(userJoinRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/users")
+                .then().log().all();
+
+        UserLoginDto loginDto = new UserLoginDto("andy", "12345");
+        String loginRequestBody = om.writeValueAsString(loginDto);
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .body(loginRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .extract();
+
+        String authHeader = response.header(AUTHORIZATION);
+
+        RestaurantDto restaurantCreateDto = RestaurantDto.builder().name("restaurant").build();
+        String restaurantCreateRequestBody = om.writeValueAsString(restaurantCreateDto);
+
+        RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, authHeader)
+                .body(restaurantCreateRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/restaurants")
+                .then().log().all()
+                .extract();
+
+        Long restaurantId = 1L;
+        int seatQuantity = 4;
+
+        SeatDto seatDto = new SeatDto(
+                SeatType.BAR,
+                List.of(LocalTime.of(13, 0, 0)),
+                1,
+                2,
+                seatQuantity
+        );
+        String seatAddRequestBody = om.writeValueAsString(seatDto);
+
+        RestAssured
+                .given().log().all()
+                .pathParam("restaurantId", restaurantId)
+                .header(AUTHORIZATION, authHeader)
+                .body(seatAddRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/restaurants/{restaurantId}/seats")
+                .then().log().all();
+
+        Long seatId = 7L;
+        TmpReservationRequestDto tmpReservationRequestDto = new TmpReservationRequestDto(seatId);
+        String tmpReservationCreateRequestBody = om.writeValueAsString(tmpReservationRequestDto);
+
+        ExtractableResponse<Response> tmpReservationResponse = RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, authHeader)
+                .body(tmpReservationCreateRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/reservations/tmp")
+                .then().log().all()
+                .extract();
+
+        assertThat(redisTemplate.hasKey(SEAT_AVAIL_QTY_PREFIX + seatId)).isTrue();
+        int availQtyCache = Integer.parseInt(redisTemplate.opsForValue().get(SEAT_AVAIL_QTY_PREFIX + seatId));
+        assertThat(availQtyCache).isEqualTo(seatQuantity - 1);
+
+        String tmpRsvId = tmpReservationResponse.path("data.tmpRsvId").toString();
+        assertThat(redisTemplate.hasKey(TMP_RSV_SEAT_ID_PREFIX + tmpRsvId)).isTrue();
+
+        RestAssured
+                .given().log().all()
+                .pathParam("tmpRsvId", tmpRsvId)
+                .header(AUTHORIZATION, authHeader)
+                .when()
+                .delete("/reservations/tmp/{tmpRsvId}")
+                .then().log().all();
+
+        availQtyCache = Integer.parseInt(redisTemplate.opsForValue().get(SEAT_AVAIL_QTY_PREFIX + seatId));
+        assertThat(availQtyCache).isEqualTo(seatQuantity);
+        assertThat(redisTemplate.hasKey(TMP_RSV_SEAT_ID_PREFIX + tmpRsvId)).isFalse();
+    }
+
+
+    @Test
+    @DisplayName("예약 취소")
+    void cancel() throws Exception {
+        UserDto userJoinDto = new UserDto("andy", "12345", "01012345678", OWNER);
+        String userJoinRequestBody = om.writeValueAsString(userJoinDto);
+
+        RestAssured
+                .given().log().all()
+                .body(userJoinRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/users")
+                .then().log().all();
+
+        UserLoginDto loginDto = new UserLoginDto("andy", "12345");
+        String loginRequestBody = om.writeValueAsString(loginDto);
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .body(loginRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/login")
+                .then().log().all()
+                .extract();
+
+        String authHeader = response.header(AUTHORIZATION);
+
+        RestaurantDto restaurantCreateDto = RestaurantDto.builder().name("restaurant").build();
+        String restaurantCreateRequestBody = om.writeValueAsString(restaurantCreateDto);
+
+        RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, authHeader)
+                .body(restaurantCreateRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/restaurants")
+                .then().log().all()
+                .extract();
+
+        Long restaurantId = 1L;
+        int seatQuantity = 4;
+
+        SeatDto seatDto = new SeatDto(
+                SeatType.BAR,
+                List.of(LocalTime.of(13, 0, 0)),
+                1,
+                2,
+                seatQuantity
+        );
+        String seatAddRequestBody = om.writeValueAsString(seatDto);
+
+        RestAssured
+                .given().log().all()
+                .pathParam("restaurantId", restaurantId)
+                .header(AUTHORIZATION, authHeader)
+                .body(seatAddRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/restaurants/{restaurantId}/seats")
+                .then().log().all();
+
+        Long seatId = 7L;
+        TmpReservationRequestDto tmpReservationRequestDto = new TmpReservationRequestDto(seatId);
+        String tmpReservationCreateRequestBody = om.writeValueAsString(tmpReservationRequestDto);
+
+        ExtractableResponse<Response> tmpReservationResponse = RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, authHeader)
+                .body(tmpReservationCreateRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/reservations/tmp")
+                .then().log().all()
+                .extract();
+
+        assertThat(redisTemplate.hasKey(SEAT_AVAIL_QTY_PREFIX + seatId)).isTrue();
+        int availQtyCache = Integer.parseInt(redisTemplate.opsForValue().get(SEAT_AVAIL_QTY_PREFIX + seatId));
+        assertThat(availQtyCache).isEqualTo(seatQuantity - 1);
+
+        String tmpRsvId = tmpReservationResponse.path("data.tmpRsvId").toString();
+        assertThat(redisTemplate.hasKey(TMP_RSV_SEAT_ID_PREFIX + tmpRsvId)).isTrue();
+
+        ReservationRequestDto reservationRequestDto = new ReservationRequestDto(
+                tmpRsvId,
+                List.of(new ReserveMenuDto("Pizza", 20000, 1)),
+                PaymentType.CREDIT_CARD,
+                2
+        );
+        String reservationCreateRequestBody = om.writeValueAsString(reservationRequestDto);
+
+        RestAssured
+                .given().log().all()
+                .header(AUTHORIZATION, authHeader)
+                .body(reservationCreateRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/reservations")
+                .then().log().all();
+
+        NotificationRequestDto notificationRequestDto = new NotificationRequestDto(
+                "fcm-token",
+                LocalDate.now().plusDays(6),
+                DiningPeriod.LUNCH,
+                2
+        );
+        String notificationRequestBody = om.writeValueAsString(notificationRequestDto);
+
+        RestAssured
+                .given().log().all()
+                .pathParam("restaurantId", restaurantId)
+                .header(AUTHORIZATION, authHeader)
+                .body(notificationRequestBody)
+                .contentType(JSON)
+                .when()
+                .post("/restaurants/{restaurantId}/notificationRequests")
+                .then().log().all()
+                .extract();
+
+        Long userId = 1L;
+        Long reservationId = 1L;
+
+        RestAssured
+                .given().log().all()
+                .pathParams("userId", userId, "reservationId", reservationId)
+                .header(AUTHORIZATION, authHeader)
+                .when()
+                .put("/users/{userId}/reservations/{reservationId}")
+                .then().log().all();
+
+        availQtyCache = Integer.parseInt(redisTemplate.opsForValue().get(SEAT_AVAIL_QTY_PREFIX + seatId));
+        assertThat(availQtyCache).isEqualTo(seatQuantity);
+
+        assertThat(redisTemplate.hasKey(TMP_RSV_SEAT_ID_PREFIX + tmpRsvId)).isFalse();
+        verify(firebaseMessaging, timeout(5000).atLeastOnce()).send(any(Message.class));
+
+        RestAssured
+                .given().log().all()
+                .pathParam("userId", userId)
+                .param("status", ReservationStatus.CANCELED)
+                .header(AUTHORIZATION, authHeader)
+                .when()
+                .get("/users/{userId}/reservations")
+                .then().log().all()
+                .assertThat()
+                .body("data", hasSize(1));
+    }
+}

--- a/src/test/java/com/jvnlee/catchdining/integration/TestcontainersContext.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/TestcontainersContext.java
@@ -13,6 +13,7 @@ import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.ComposeContainer;
@@ -24,6 +25,7 @@ import java.util.List;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestInstance(Lifecycle.PER_CLASS)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ActiveProfiles("test")
 public class TestcontainersContext {
 
     private static final String WRITE_DB = "write-db";

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,4 @@
 spring:
-  profiles:
-    active: test
   datasource:
     username: root
     password: 1234


### PR DESCRIPTION
## 구현 내용

#60 이슈에서 제기된 문제 해결

&nbsp;

## 문제 원인

임시 예약 기능을 추가한 #53 에서 기존 예약 취소 메서드인 `cancel()`을 리팩토링함

이 때 RabbitMQ로 `ReservationCancelledEvent`를 발행하여 빈자리 알림 기능을 비동기로 호출하도록 변경했는데, 해당 이벤트 객체가 직렬화되지 않아 예약 취소만 성공하고 의도한 빈자리 알림이 제대로 이루어지지 않음.

게다가 나름대로 기능 개발마다 테스트 코드를 작성하고 있는데도 해당 문제가 발생한지 모르고 merge했다는 점이 2차적인 문제.

&nbsp;

## 해결

### Jackson2JsonMessageConverter 설정 추가

`RabbitMQConfig`에 등록한 메시지 변환기 Bean

Converter가 사용중인 ObjectMapper에 `findAndRegisterModules()`로 이벤트 객체 직렬화에 필요한 모든 classpath 모듈을 등록하여 사용하도록 변경

문제가 되었던 enum 타입이나 그 외 다양한 특수 타입에 대한 직렬화를 가능하게 만듦

&nbsp;

### ReservationCancelTest 통합테스트 추가

문제가 발생한 곳인 `ReservationService`처럼 다양한 모듈이 상호작용하는 기능을 만질 때는 반드시 통합테스트를 잘 작성해야한다는 것을 다시 한번 느낌.

테스트를 작성하면서 통합테스트 클래스간 데이터 독립성이나 중복 로직 (주로 데이터 세팅 관련) 등 문제점이 많이 보였음 (추후 별도 이슈로 빼서 해결 예정)