### PR TITLE
feature/#62 integration test independence application

### DIFF
--- a/src/main/java/com/jvnlee/catchdining/common/config/DataSourceConfig.java
+++ b/src/main/java/com/jvnlee/catchdining/common/config/DataSourceConfig.java
@@ -3,11 +3,11 @@ package com.jvnlee.catchdining.common.config;
 import com.jvnlee.catchdining.common.util.DataSourceRouter;
 import com.jvnlee.catchdining.common.util.DataSourceType;
 import com.zaxxer.hikari.HikariDataSource;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
 import javax.sql.DataSource;
@@ -75,9 +75,10 @@ public class DataSourceConfig {
         return dataSourceRouter;
     }
 
+    @Primary
     @Bean(name = "lazyDataSource")
-    public DataSource lazyDataSource(@Qualifier("dataSourceRouter") DataSource dataSource) {
-        return new LazyConnectionDataSourceProxy(dataSource);
+    public DataSource lazyDataSource() {
+        return new LazyConnectionDataSourceProxy(dataSourceRouter());
     }
 
 }

--- a/src/test/java/com/jvnlee/catchdining/CatchdiningApplicationTests.java
+++ b/src/test/java/com/jvnlee/catchdining/CatchdiningApplicationTests.java
@@ -2,9 +2,7 @@ package com.jvnlee.catchdining;
 
 import com.jvnlee.catchdining.integration.TestcontainersContext;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class CatchdiningApplicationTests extends TestcontainersContext {
 
 	@Test

--- a/src/test/java/com/jvnlee/catchdining/integration/FirebaseMessagingServiceTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/FirebaseMessagingServiceTest.java
@@ -8,16 +8,13 @@ import com.jvnlee.catchdining.domain.notification.service.FirebaseMessagingServi
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.annotation.EnableRetry;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT)
 @EnableRetry
 public class FirebaseMessagingServiceTest extends TestcontainersContext {
 

--- a/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/LoginIntegrationTest.java
@@ -6,34 +6,21 @@ import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 
 import static com.jvnlee.catchdining.domain.user.model.UserType.*;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpStatus.*;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT)
 class LoginIntegrationTest extends TestcontainersContext {
-
-    @LocalServerPort
-    int port;
 
     @Autowired
     ObjectMapper om;
-
-    @BeforeEach
-    void beforeEach() {
-        RestAssured.port = port;
-    }
 
     @Test
     @DisplayName("username password 로그인 성공")

--- a/src/test/java/com/jvnlee/catchdining/integration/ReservationIntegrationTest.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/ReservationIntegrationTest.java
@@ -14,12 +14,9 @@ import com.jvnlee.catchdining.domain.user.dto.UserLoginDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -30,24 +27,14 @@ import java.util.concurrent.Executors;
 import static com.jvnlee.catchdining.domain.user.model.UserType.OWNER;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.Matchers.hasSize;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT)
 class ReservationIntegrationTest extends TestcontainersContext {
-
-    @LocalServerPort
-    int port;
 
     @Autowired
     ObjectMapper om;
 
     final int THREAD_COUNT = 100;
-
-    @BeforeEach
-    void beforeEach() {
-        RestAssured.port = port;
-    }
 
     @Test
     @DisplayName("10개 수량의 좌석에 대한 100개의 예약 요청 동시성 테스트")

--- a/src/test/java/com/jvnlee/catchdining/integration/TestcontainersContext.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/TestcontainersContext.java
@@ -1,18 +1,26 @@
 package com.jvnlee.catchdining.integration;
 
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.ComposeContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.io.File;
+import java.util.List;
 
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class TestcontainersContext {
 
     private static final String WRITE_DB = "write-db";
     private static final String READ_DB = "read-db";
     private static final int MYSQL_PORT = 3306;
-    private static final String JDBC_URL_FORMAT = "jdbc:mysql://%s:%d/catch_dining";
+    private static final String DATABASE_NAME = "catch_dining";
+    private static final String JDBC_URL_FORMAT = "jdbc:mysql://%s:%d/%s";
 
     private static final String REDIS = "redis";
     private static final int REDIS_PORT = 6379;
@@ -22,6 +30,9 @@ public class TestcontainersContext {
 
     private static final ComposeContainer COMPOSE_CONTAINER;
     private static final String COMPOSE_FILE_PATH = "src/test/resources/docker-compose.test.yml";
+
+    @LocalServerPort
+    private int port;
 
     static {
         COMPOSE_CONTAINER =
@@ -57,6 +68,11 @@ public class TestcontainersContext {
 
         registry.add("spring.rabbitmq.host", () -> COMPOSE_CONTAINER.getServiceHost(RABBITMQ, RABBITMQ_PORT));
         registry.add("spring.rabbitmq.port", () -> COMPOSE_CONTAINER.getServicePort(RABBITMQ, RABBITMQ_PORT));
+    }
+
+    @BeforeEach
+    void setup() {
+        RestAssured.port = port;
     }
 
 }

--- a/src/test/java/com/jvnlee/catchdining/integration/TestcontainersContext.java
+++ b/src/test/java/com/jvnlee/catchdining/integration/TestcontainersContext.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.ComposeContainer;
@@ -22,6 +23,7 @@ import java.util.List;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestInstance(Lifecycle.PER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class TestcontainersContext {
 
     private static final String WRITE_DB = "write-db";


### PR DESCRIPTION
## 구현 내용

Testcontainers에 통합 테스트 클래스 간 독립성 보장을 위한 장치 추가

&nbsp;

### 1. 데이터 초기화

클래스 내의 모든 테스트 메서드를 실행하고 난 이후, `@AfterAll` 메서드인 `cleanup()` 메서드를 호출

주입 받은 `JdbcTemplate`과 `RedisTemplate` Bean으로 DB와 캐시 데이터를 모두 제거함

Bean 사용을 위해서는 `cleanup()`이 기본 설정과는 다르게 non-static 메서드여야 하므로, `@TestInstance(Lifecycle.PER_CLASS)` 어노테이션으로 테스트 클래스 인스턴스가 클래스 당 오직 하나만 생성되도록 변경함.

> JUnit5 기본 설정인 `Lifecycle.PER_METHOD`는 하나의 클래스 안에서 테스트 메서드마다 개별적인 테스트 클래스 인스턴스를 사용하도록 한다. 그런데 `@AfterAll`은 특정 인스턴스에 종속되어서는 안되고 모든 메서드가 종료된 이후 실행되어야 하므로, `static`이 강요된다.

&nbsp;

### 2. Application Context 초기화

`Testcontainers`를 상속 받는 모든 클래스는 `@SpringBootTest`의 효과로 동일한 Application Context를 가짐

그러나 이는 Bean State 변화로 테스트 간 의도치 않은 영향을 초래할 수 있으므로, 각 테스트 클래스가 새로운 Context 안에서 실행될 수 있도록  `@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)`를 사용함

이제 클래스가 종료될 때마다 Application Context를 파괴하고 클래스가 새로운 Application Context를 생성해서 사용하게 됨